### PR TITLE
Remove escape nodes

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -27,6 +27,8 @@ module.exports = {
         'breaks': false
     },
     'stringify': {
+        'gfm': true,
+        'commonmark': false,
         'entities': 'false',
         'setext': false,
         'closeAtx': false,

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -33,6 +33,10 @@ var raise = utilities.raise;
 var clean = utilities.clean;
 var validate = utilities.validate;
 var normalize = utilities.normalizeIdentifier;
+var stateToggler = utilities.stateToggler;
+var noopToggler = utilities.noopToggler;
+var mergeable = utilities.mergeable;
+var MERGEABLE_NODES = utilities.MERGEABLE_NODES;
 var arrayPush = [].push;
 
 /*
@@ -76,7 +80,6 @@ var BLOCKQUOTE = 'blockquote';
 var LINK = 'link';
 var IMAGE = 'image';
 var FOOTNOTE = 'footnote';
-var ESCAPE = 'escape';
 var STRONG = 'strong';
 var EMPHASIS = 'emphasis';
 var DELETE = 'delete';
@@ -395,149 +398,6 @@ function getAlignment(cells) {
 
     return results;
 }
-
-/**
- * Construct a state `toggler`: a function which inverses
- * `property` in context based on its current value.
- * The by `toggler` returned function restores that value.
- *
- * @example
- *   var context = {};
- *   var key = 'foo';
- *   var val = true;
- *   context[key] = val;
- *   context.enter = stateToggler(key, val);
- *   context[key]; // true
- *   var exit = context.enter();
- *   context[key]; // false
- *   var nested = context.enter();
- *   context[key]; // false
- *   nested();
- *   context[key]; // false
- *   exit();
- *   context[key]; // true
- *
- * @param {string} key - Property to toggle.
- * @param {boolean} state - It's default state.
- * @return {function(): function()} - Enter.
- */
-function stateToggler(key, state) {
-    /**
-     * Construct a toggler for the bound `key`.
-     *
-     * @return {Function} - Exit state.
-     */
-    function enter() {
-        var self = this;
-        var current = self[key];
-
-        self[key] = !state;
-
-        /**
-         * State canceler, cancels the state, if allowed.
-         */
-        function exit() {
-            self[key] = current;
-        }
-
-        return exit;
-    }
-
-    return enter;
-}
-
-/**
- * Construct a state toggler which doesn't toggle.
- *
- * @example
- *   var context = {};
- *   var key = 'foo';
- *   var val = true;
- *   context[key] = val;
- *   context.enter = noopToggler();
- *   context[key]; // true
- *   var exit = context.enter();
- *   context[key]; // true
- *   exit();
- *   context[key]; // true
- *
- * @return {function(): function()} - Enter.
- */
-function noopToggler() {
-    /**
-     * No-operation.
-     */
-    function exit() {}
-
-    /**
-     * @return {Function}
-     */
-    function enter() {
-        return exit;
-    }
-
-    return enter;
-}
-
-/*
- * Define nodes of a type which can be merged.
- */
-
-var MERGEABLE_NODES = {};
-
-/**
- * Merge two text nodes: `node` into `prev`.
- *
- * @param {Object} prev - Preceding sibling.
- * @param {Object} node - Following sibling.
- * @return {Object} - `prev`.
- */
-MERGEABLE_NODES.text = function (prev, node) {
-    prev.value += node.value;
-
-    return prev;
-};
-
-/**
- * Merge two blockquotes: `node` into `prev`, unless in
- * CommonMark mode.
- *
- * @param {Object} prev - Preceding sibling.
- * @param {Object} node - Following sibling.
- * @return {Object} - `prev`, or `node` in CommonMark mode.
- */
-MERGEABLE_NODES.blockquote = function (prev, node) {
-    if (this.options.commonmark) {
-        return node;
-    }
-
-    prev.children = prev.children.concat(node.children);
-
-    return prev;
-};
-
-/**
- * Merge two lists: `node` into `prev`. Knows, about
- * which bullets were used.
- *
- * @param {Object} prev - Preceding sibling.
- * @param {Object} node - Following sibling.
- * @return {Object} - `prev`, or `node` when the lists are
- *   of different types (a different bullet is used).
- */
-MERGEABLE_NODES.list = function (prev, node) {
-    if (
-        !this.currentBullet ||
-        this.currentBullet !== this.previousBullet ||
-        this.currentBullet.length !== 1
-    ) {
-        return node;
-    }
-
-    prev.children = prev.children.concat(node.children);
-
-    return prev;
-};
 
 /**
  * Tokenise a line.  Unsets `currentBullet` and
@@ -1577,16 +1437,25 @@ function renderBlock(type, value, position) {
 /**
  * Tokenise an escape sequence.
  *
+ * Note that `$1` can only contain escapable characters per
+ * the used method, e.g., `\n` is only included when
+ * `commonmark: true`.
+ *
  * @example
  *   tokenizeEscape(eat, '\\a', 'a');
  *
  * @param {function(string)} eat
  * @param {string} $0 - Whole escape.
  * @param {string} $1 - Escaped character.
- * @return {Node} - `escape` node.
+ * @return {Node} - `text` node, or `break` node if
+ *   commonmark and the value is `'\n'`.
  */
 function tokenizeEscape(eat, $0, $1) {
-    return eat($0)(this.renderRaw(ESCAPE, $1));
+    if ($1 == '\n') {
+        return tokenizeBreak.call(this, eat, $0);
+    }
+
+    return eat($0)(this.renderRaw(TEXT, $1));
 }
 
 /**
@@ -2191,7 +2060,7 @@ function tokenizeFactory(type) {
         }
 
         /**
-         * Get offset. Called before the fisrt character is
+         * Get offset. Called before the first character is
          * eaten to retrieve the range's offsets.
          *
          * @return {Function} - `done`, to be called when
@@ -2342,7 +2211,7 @@ function tokenizeFactory(type) {
                     indent = combined.concat(indent);
                 }
 
-                node.position.indent = indent;
+                node.position.indent = indent || [];
 
                 return node;
             }
@@ -2386,7 +2255,9 @@ function tokenizeFactory(type) {
                 if (
                     prev &&
                     node.type === prev.type &&
-                    node.type in MERGEABLE_NODES
+                    node.type in MERGEABLE_NODES &&
+                    mergeable(prev) &&
+                    mergeable(node)
                 ) {
                     node = MERGEABLE_NODES[node.type].call(
                         self, prev, node
@@ -2429,10 +2300,12 @@ function tokenizeFactory(type) {
              * Add the given arguments, add `position` to
              * the returned node, and return the node.
              *
+             * @param {Object} node - Node to add.
+             * @param {Object} [parent] - Node to insert into.
              * @return {Node}
              */
-            function apply() {
-                return pos(add.apply(null, arguments), indent);
+            function apply(node, parent) {
+                return pos(add(pos(node), parent), indent);
             }
 
             /**

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -31,6 +31,9 @@ var defaultOptions = require('./defaults.js').stringify;
 
 var raise = utilities.raise;
 var validate = utilities.validate;
+var stateToggler = utilities.stateToggler;
+var mergeable = utilities.mergeable;
+var MERGEABLE_NODES = utilities.MERGEABLE_NODES;
 
 /*
  * Constants.
@@ -65,21 +68,32 @@ var FENCE = /([`~])\1{2}/;
 var PROTOCOL = /^[a-z][a-z+.-]+:\/?/i;
 
 /*
+ * Punctuation characters.
+ */
+
+var PUNCTUATION = /[-!"#$%&'()*+,.\/:;<=>?@\[\\\]^`{|}~_]/;
+
+/*
  * Characters.
  */
 
 var ANGLE_BRACKET_CLOSE = '>';
 var ANGLE_BRACKET_OPEN = '<';
 var ASTERISK = '*';
+var BACKSLASH = '\\';
 var CARET = '^';
 var COLON = ':';
+var SEMICOLON = ';';
 var DASH = '-';
 var DOT = '.';
 var EMPTY = '';
 var EQUALS = '=';
 var EXCLAMATION_MARK = '!';
 var HASH = '#';
+var AMPERSAND = '&';
 var LINE = '\n';
+var CARRIAGE = '\r';
+var FORM_FEED = '\f';
 var PARENTHESIS_OPEN = '(';
 var PARENTHESIS_CLOSE = ')';
 var PIPE = '|';
@@ -87,6 +101,8 @@ var PLUS = '+';
 var QUOTE_DOUBLE = '"';
 var QUOTE_SINGLE = '\'';
 var SPACE = ' ';
+var TAB = '\t';
+var VERTICAL_TAB = '\u000B';
 var SQUARE_BRACKET_OPEN = '[';
 var SQUARE_BRACKET_CLOSE = ']';
 var TICK = '`';
@@ -283,6 +299,234 @@ function encodeFactory(type, file) {
 }
 
 /**
+ * Check if a string starts with HTML entity.
+ *
+ * @example
+ *   startsWithEntity('&copycat') // true
+ *   startsWithEntity('&foo &amp &bar') // false
+ *
+ * @param {string} string
+ * @return {boolean}
+ */
+function startsWithEntity(string) {
+    var prefix;
+
+    if (string.charAt(0) !== AMPERSAND) {
+        return false;
+    }
+
+    prefix = string.split(AMPERSAND, 2).join(AMPERSAND);
+    return he.decode(prefix).length !== prefix.length;
+}
+
+/**
+ * Factory to escape characters.
+ *
+ * @example
+ *   var escape = escapeFactory({ commonmark: true });
+ *   escape('x*x', { type: 'text', value: 'x*x' }) // 'x\\*x'
+ *
+ * @param {Object} options - Compiler options.
+ * @return {function(value, node, parent): string} - Function which
+ *   takes a value and a node and (optionally) its parent and returns
+ *   its escaped value.
+ */
+function escapeFactory(options) {
+    /**
+     * Escape punctuation characters in a node's value.
+     *
+     * @param {string} value
+     * @param {Object} node
+     * @param {Object} [parent]
+     * @return {string}
+     */
+    return function escape (value, node, parent) {
+        var siblings = parent && parent.children;
+        var gfm = options.gfm;
+        var commonmark = options.commonmark;
+        var length = value.length;
+        var position = -1;
+        var afterNewLine;
+        var queue = [];
+        var escaped = queue;
+        var index = siblings && siblings.indexOf(node);
+        var prev = siblings && siblings[index - 1];
+        var next = siblings && siblings[index + 1];
+        var character;
+
+        if (prev) {
+            afterNewLine = prev.type === 'text' && /\n\s*$/.test(prev.value);
+        } else if (parent) {
+            afterNewLine = parent.type === 'paragraph';
+        }
+
+        while (++position < length) {
+            character = value.charAt(position);
+
+            if (
+                character === BACKSLASH ||
+                character === TICK ||
+                character === ASTERISK ||
+                character === SQUARE_BRACKET_OPEN ||
+                character === UNDERSCORE ||
+                (
+                    character === ANGLE_BRACKET_OPEN &&
+                    commonmark
+                ) ||
+                (
+                    character === PIPE &&
+                    gfm
+                )
+            ) {
+                queue.push(BACKSLASH);
+            } else if (
+                character === COLON &&
+                gfm &&
+                !this.inLink &&
+                (
+                    queue.slice(-4).join('') === 'http' ||
+                    queue.slice(-5).join('') === 'https'
+                )
+            ) {
+                if (commonmark) {
+                    queue.push(BACKSLASH);
+                } else {
+                    queue.push(AMPERSAND, 'colon', SEMICOLON);
+                    continue;
+                }
+            } else if (
+                character === AMPERSAND &&
+                startsWithEntity(value.slice(position))
+            ) {
+                if (commonmark) {
+                    queue.push(BACKSLASH);
+                } else {
+                    queue.push(AMPERSAND, 'amp', SEMICOLON);
+                    continue;
+                }
+            } else if (
+                character === TILDE &&
+                value.charAt(position + 1) === TILDE &&
+                gfm
+            ) {
+                queue.push(BACKSLASH, TILDE);
+                position += 1;
+            } else if (character === LINE) {
+                afterNewLine = true;
+            } else if (afterNewLine) {
+                if (
+                    character === ANGLE_BRACKET_CLOSE ||
+                    character === HASH ||
+                    LIST_BULLETS[character]
+                ) {
+                    queue.push(BACKSLASH);
+                } else if (
+                    character !== SPACE &&
+                    character !== TAB &&
+                    character !== CARRIAGE &&
+                    character !== VERTICAL_TAB &&
+                    character !== FORM_FEED
+                ) {
+                    afterNewLine = false;
+                }
+            }
+
+            queue.push(character);
+        }
+
+        /*
+         * Multi-node versions.
+         */
+
+        if (siblings && node.type === 'text') {
+            /*
+             * Check for an opening parentheses after a
+             * link-reference (which can be joined by
+             * white-space).
+             */
+
+            if (
+                prev &&
+                prev.type === 'linkReference' &&
+                prev.referenceType === 'shortcut'
+            ) {
+                position = -1;
+                length = escaped.length;
+
+                while (++position < length) {
+                    character = escaped[position];
+
+                    if (character === SPACE || character === TAB) {
+                        continue;
+                    }
+
+                    if (character === PARENTHESIS_OPEN) {
+                        escaped.splice(position, 0, BACKSLASH);
+                    }
+
+                    break;
+                }
+            }
+
+            /*
+             * Ensure non-auto-links are not seen links.
+             * This pattern needs to check the preceding
+             * nodes too.
+             */
+
+            if (
+                value.charAt(0) === COLON &&
+                prev && prev.type === 'text' &&
+                gfm &&
+                !this.inLink
+            ) {
+                queue = prev.value.slice(-5);
+
+                if (queue === 'https' || queue.slice(-4) === 'http') {
+                    if (commonmark) {
+                        escaped.unshift(BACKSLASH);
+                    } else {
+                        escaped.splice(0, 1, AMPERSAND, 'colon', SEMICOLON);
+                    }
+                }
+            }
+
+            /*
+             * Escape ampersand if it would otherwise
+             * start an entity.
+             */
+
+            if (
+                value.slice(-1) === AMPERSAND &&
+                next && next.type === 'text' &&
+                startsWithEntity(AMPERSAND + next.value)
+            ) {
+                if (commonmark) {
+                    escaped.splice(escaped.length - 1, 0, BACKSLASH);
+                } else {
+                    escaped.push('amp', SEMICOLON);
+                }
+            }
+
+            /*
+             * Escape double tildes in GFM.
+             */
+
+            if (
+                value.slice(-1) === TILDE &&
+                next && next.type === 'text' &&
+                next.value.charAt(0) === TILDE &&
+                gfm
+            ) {
+                escaped.splice(escaped.length - 1, 0, BACKSLASH);
+            }
+        }
+
+        return escaped.join('');
+    };
+}
+
+/**
  * Wrap `url` in angle brackets when needed, or when
  * forced.
  *
@@ -463,11 +707,18 @@ compilerPrototype.setOptions = function (options) {
     }
 
     self.encode = encodeFactory(String(options.entities), self.file);
+    self.escape = escapeFactory(options);
 
     self.options = options;
 
     return self;
 };
+
+/*
+ * Enter and exit helpers.
+ */
+
+compilerPrototype.enterLink = stateToggler('inLink', false);
 
 /**
  * Visit a node.
@@ -532,13 +783,34 @@ compilerPrototype.all = function (parent) {
     var self = this;
     var children = parent.children;
     var values = [];
-    var index = -1;
+    var index = 0;
     var length = children.length;
+    var node = children[0];
+    var next;
 
-    while (++index < length) {
-        values[index] = self.visit(children[index], parent);
+    if (length === 0) {
+        return values;
     }
 
+    while (++index < length) {
+        next = children[index];
+
+        if (
+            node.type === next.type &&
+            node.type in MERGEABLE_NODES &&
+            mergeable(node) &&
+            mergeable(next)
+        ) {
+            node = MERGEABLE_NODES[node.type].call(
+                self, node, next
+            );
+        } else {
+            values.push(self.visit(node, parent));
+            node = next;
+        }
+    }
+
+    values.push(self.visit(node, parent));
     return values;
 };
 
@@ -823,27 +1095,8 @@ compilerPrototype.heading = function (node) {
  * @param {Object} node - `text` node.
  * @return {string} - Raw markdown text.
  */
-compilerPrototype.text = function (node) {
-    return this.encode(node.value, node);
-};
-
-/**
- * Stringify escaped text.
- *
- * @example
- *   var compiler = new Compiler();
- *
- *   compiler.escape({
- *     type: 'escape',
- *     value: '\n'
- *   });
- *   // '\\\n'
- *
- * @param {Object} node - `escape` node.
- * @return {string} - Markdown escape.
- */
-compilerPrototype.escape = function (node) {
-    return '\\' + node.value;
+compilerPrototype.text = function (node, parent) {
+    return this.encode(this.escape(node.value, node, parent), node);
 };
 
 /**
@@ -1291,6 +1544,10 @@ compilerPrototype.emphasis = function (node) {
 /**
  * Stringify a hard break.
  *
+ * In Commonmark mode, trailing backslash form is used in order
+ * to preserve trailing whitespace that the line may end with,
+ * and also for better visibility.
+ *
  * @example
  *   var compiler = new Compiler();
  *
@@ -1302,7 +1559,7 @@ compilerPrototype.emphasis = function (node) {
  * @return {string} - Hard markdown break.
  */
 compilerPrototype.break = function () {
-    return SPACE + SPACE + LINE;
+    return this.options.commonmark ? BACKSLASH + LINE : SPACE + SPACE + LINE;
 };
 
 /**
@@ -1364,20 +1621,29 @@ compilerPrototype.delete = function (node) {
 compilerPrototype.link = function (node) {
     var self = this;
     var url = self.encode(node.href, node);
+    var exitLink = self.enterLink();
     var value = self.all(node).join(EMPTY);
+    exitLink();
 
     if (
         node.title === null &&
         PROTOCOL.test(url) &&
         (url === value || url === MAILTO + value)
     ) {
-        return encloseURI(url, true);
+        /*
+         * Backslash escapes do not work in autolinks,
+         * so we do not escape.
+         */
+
+        return encloseURI(self.encode(node.href), true);
     }
 
     url = encloseURI(url);
 
     if (node.title) {
-        url += SPACE + encloseTitle(self.encode(node.title, node));
+        url += SPACE + encloseTitle(self.encode(self.escape(
+            node.title, node
+        ), node));
     }
 
     value = SQUARE_BRACKET_OPEN + value + SQUARE_BRACKET_CLOSE;
@@ -1438,6 +1704,77 @@ function label(node) {
 }
 
 /**
+ * For shortcut reference links, the contents is also an
+ * identifier, and for identifiers extra backslashes do
+ * matter.
+ *
+ * This function takes an escaped value from shortcut's children
+ * and an identifier and removes extra backslashes.
+ *
+ * @example
+ *   unescapeShortcutLinkReference('a\\*b', 'a*b')
+ *   // 'a*b'
+ *
+ * @param {string} value - Escaped and stringified link value.
+ * @param {string} identifier - Link identifier, in one of its
+ *   equivalent forms.
+ * @return {string} - Link value with some characters unescaped.
+ */
+function unescapeShortcutLinkReference(value, identifier) {
+    var valueIndex = 0, identifierIndex = 0;
+    var result = [];
+    var startIndex;
+
+    while (valueIndex < value.length) {
+        /*
+         * Take next non-punctuation characters from `value`.
+         */
+        startIndex = valueIndex;
+        while (
+            valueIndex < value.length &&
+            !PUNCTUATION.test(value[valueIndex])
+        ) {
+            valueIndex += 1;
+        }
+        result.push(value.slice(startIndex, valueIndex));
+
+        /*
+         * Advance `identifierIndex` to the next punctuation character.
+         */
+        while (
+            identifierIndex < identifier.length &&
+            !PUNCTUATION.test(identifier[identifierIndex])
+        ) {
+            identifierIndex += 1;
+        }
+
+        /*
+         * Take next punctuation characters from `identifier`.
+         */
+        startIndex = identifierIndex;
+        while (
+            identifierIndex < identifier.length &&
+            PUNCTUATION.test(identifier[identifierIndex])
+        ) {
+            identifierIndex += 1;
+        }
+        result.push(identifier.slice(startIndex, identifierIndex));
+
+        /*
+         * Advance `valueIndex` to the next non-punctuation character.
+         */
+        while (
+            valueIndex < value.length &&
+            PUNCTUATION.test(value[valueIndex])
+        ) {
+            valueIndex += 1;
+        }
+    }
+
+    return result.join('');
+}
+
+/**
  * Stringify a link reference.
  *
  * See `label()` on how reference labels are created.
@@ -1460,9 +1797,15 @@ function label(node) {
  * @return {string} - Markdown link reference.
  */
 compilerPrototype.linkReference = function (node) {
-    return SQUARE_BRACKET_OPEN +
-        this.all(node).join(EMPTY) + SQUARE_BRACKET_CLOSE +
-        label(node);
+    var exitLink = this.enterLink();
+    var value = this.all(node).join(EMPTY);
+    exitLink();
+
+    if (node.referenceType == 'shortcut') {
+        value = unescapeShortcutLinkReference(value, node.identifier);
+    }
+
+    return SQUARE_BRACKET_OPEN + value + SQUARE_BRACKET_CLOSE + label(node);
 };
 
 /**
@@ -1574,16 +1917,15 @@ compilerPrototype.definition = function (node) {
  * @return {string} - Markdown image.
  */
 compilerPrototype.image = function (node) {
-    var encode = this.encode;
-    var url = encloseURI(encode(node.src, node));
+    var url = encloseURI(this.encode(node.src, node));
     var value;
 
     if (node.title) {
-        url += SPACE + encloseTitle(encode(node.title, node));
+        url += SPACE + encloseTitle(this.encode(node.title, node));
     }
 
     value = EXCLAMATION_MARK +
-        SQUARE_BRACKET_OPEN + encode(node.alt || EMPTY, node) +
+        SQUARE_BRACKET_OPEN + this.encode(node.alt || EMPTY, node) +
         SQUARE_BRACKET_CLOSE;
 
     value += PARENTHESIS_OPEN + url + PARENTHESIS_CLOSE;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -164,6 +164,175 @@ function normalizeIdentifier(value) {
     return collapseWhiteSpace(value).toLowerCase();
 }
 
+/**
+ * Construct a state `toggler`: a function which inverses
+ * `property` in context based on its current value.
+ * The by `toggler` returned function restores that value.
+ *
+ * @example
+ *   var context = {};
+ *   var key = 'foo';
+ *   var val = true;
+ *   context[key] = val;
+ *   context.enter = stateToggler(key, val);
+ *   context[key]; // true
+ *   var exit = context.enter();
+ *   context[key]; // false
+ *   var nested = context.enter();
+ *   context[key]; // false
+ *   nested();
+ *   context[key]; // false
+ *   exit();
+ *   context[key]; // true
+ *
+ * @param {string} key - Property to toggle.
+ * @param {boolean} state - It's default state.
+ * @return {function(): function()} - Enter.
+ */
+function stateToggler(key, state) {
+    /**
+     * Construct a toggler for the bound `key`.
+     *
+     * @return {Function} - Exit state.
+     */
+    function enter() {
+        var self = this;
+        var current = self[key];
+
+        self[key] = !state;
+
+        /**
+         * State canceler, cancels the state, if allowed.
+         */
+        function exit() {
+            self[key] = current;
+        }
+
+        return exit;
+    }
+
+    return enter;
+}
+
+/**
+ * Construct a state toggler which doesn't toggle.
+ *
+ * @example
+ *   var context = {};
+ *   var key = 'foo';
+ *   var val = true;
+ *   context[key] = val;
+ *   context.enter = noopToggler();
+ *   context[key]; // true
+ *   var exit = context.enter();
+ *   context[key]; // true
+ *   exit();
+ *   context[key]; // true
+ *
+ * @return {function(): function()} - Enter.
+ */
+function noopToggler() {
+    /**
+     * No-operation.
+     */
+    function exit() {}
+
+    /**
+     * @return {Function}
+     */
+    function enter() {
+        return exit;
+    }
+
+    return enter;
+}
+
+/*
+ * Define nodes of a type which can be merged.
+ */
+
+var MERGEABLE_NODES = {};
+
+/**
+ * Check whether a node is mergeable with adjacent nodes.
+ *
+ * @param {Object} node
+ * @return {boolean}
+ */
+function mergeable(node) {
+    var start;
+    var end;
+
+    if (node.type !== 'text' || !node.position) {
+        return true;
+    }
+
+    start = node.position.start;
+    end = node.position.end;
+
+    /*
+     * Only merge nodes which occupy the same size as their
+     * `value`.
+     */
+
+    return start.line !== end.line ||
+        end.column - start.column === node.value.length;
+}
+
+/**
+ * Merge two text nodes: `node` into `prev`.
+ *
+ * @param {Object} prev - Preceding sibling.
+ * @param {Object} node - Following sibling.
+ * @return {Object} - `prev`.
+ */
+MERGEABLE_NODES.text = function (prev, node) {
+    prev.value += node.value;
+
+    return prev;
+};
+
+/**
+ * Merge two blockquotes: `node` into `prev`, unless in
+ * CommonMark mode.
+ *
+ * @param {Object} prev - Preceding sibling.
+ * @param {Object} node - Following sibling.
+ * @return {Object} - `prev`, or `node` in CommonMark mode.
+ */
+MERGEABLE_NODES.blockquote = function (prev, node) {
+    if (this.options.commonmark) {
+        return node;
+    }
+
+    prev.children = prev.children.concat(node.children);
+
+    return prev;
+};
+
+/**
+ * Merge two lists: `node` into `prev`. Knows, about
+ * which bullets were used.
+ *
+ * @param {Object} prev - Preceding sibling.
+ * @param {Object} node - Following sibling.
+ * @return {Object} - `prev`, or `node` when the lists are
+ *   of different types (a different bullet is used).
+ */
+MERGEABLE_NODES.list = function (prev, node) {
+    if (
+        !this.currentBullet ||
+        this.currentBullet !== this.previousBullet ||
+        this.currentBullet.length !== 1
+    ) {
+        return node;
+    }
+
+    prev.children = prev.children.concat(node.children);
+
+    return prev;
+};
+
 /*
  * Expose `validate`.
  */
@@ -181,3 +350,7 @@ exports.validate = {
 exports.normalizeIdentifier = normalizeIdentifier;
 exports.clean = clean;
 exports.raise = raise;
+exports.stateToggler = stateToggler;
+exports.noopToggler = noopToggler;
+exports.mergeable = mergeable;
+exports.MERGEABLE_NODES = MERGEABLE_NODES;

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -121,7 +121,11 @@ function parseOptions(name) {
             ) {
                 options.stringify[key] = value;
 
-                results.push(parts[index]);
+                // Protect common options from `parse` and `stringify` from
+                // appearing twice.
+                if (results.indexOf(parts[index]) < 0) {
+                    results.push(parts[index]);
+                }
             }
         }
     }

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@
 var assert = require('assert');
 var he = require('he');
 var VFile = require('vfile');
+var extend = require('extend.js');
 var mdast = require('..');
 var fixtures = require('./fixtures.js');
 var badges = require('./badges.js');
@@ -1115,6 +1116,33 @@ validateToken = function (context) {
 };
 
 /**
+ * Compress array of nodes by merging adjacent text nodes when possible.
+ *
+ * This usually happens inside Parser, but it also needs to be done whenever
+ * position info is stripped from the AST.
+ *
+ * @param {Array.<Object>} nodes
+ * @return {Array.<Object>}
+ */
+function mergeTextNodes(nodes) {
+    if (!nodes.length || nodes[0].position) {
+        return nodes;
+    }
+
+    var result = [nodes[0]];
+
+    nodes.slice(1).forEach(function (node) {
+        if (node.type == 'text' && result[result.length - 1].type == 'text') {
+            result[result.length - 1].value += node.value;
+        } else {
+            result.push(node);
+        }
+    });
+
+    return result;
+}
+
+/**
  * Clone, and optionally clean from `position`, a node.
  *
  * @param {Object} node
@@ -1136,7 +1164,7 @@ function clone(node, clean) {
         }
 
         /*
-         * Ignore `checked` attributes se to `null`,
+         * Ignore `checked` attributes set to `null`,
          * which only exist in `gfm` on list-items
          * without a checkbox.  This ensures less
          * needed fixtures.
@@ -1148,6 +1176,9 @@ function clone(node, clean) {
 
         if (value !== null && typeof value === 'object') {
             result[key] = clone(value, clean);
+            if (key === 'children' && clean) {
+                result[key] = mergeTextNodes(result[key]);
+            }
         } else {
             result[key] = value;
         }
@@ -1193,6 +1224,10 @@ describe('fixtures', function () {
             Object.keys(possibilities).forEach(function (key) {
                 var name = key || 'default';
                 var parse = possibilities[key];
+                var stringify = extend({}, fixture.stringify, {
+                    gfm: parse.gfm,
+                    commonmark: parse.commonmark
+                });
                 var initialClean = !parse.position;
                 var node;
                 var markdown;
@@ -1209,7 +1244,7 @@ describe('fixtures', function () {
 
                     compare(node, trees[mapping[key]], false, initialClean);
 
-                    markdown = mdast.stringify(node, fixture.stringify);
+                    markdown = mdast.stringify(node, stringify);
                 });
 
                 if (output !== false) {

--- a/test/input/stringify-escape.output.commonmark.text
+++ b/test/input/stringify-escape.output.commonmark.text
@@ -1,0 +1,58 @@
+Characters that should be escaped in general:
+
+\\ \` \* \[ \_
+
+Characters that shouldn't:
+
+{}]()#+-.!>"$%',/:;=?@^~
+
+Ampersands are escaped only when they would otherwise start an entity:
+
+-   \&copycat \&amp; \&#x26
+-   But: &copycat; `&between;` &foo; & AT&T &c
+
+Open parenthesis should be escaped after a shortcut reference:
+
+[ref]\(text)
+
+Hyphen should be escaped at the beginning of a line:
+
+\- not a list item
+\- not a list item
+  \+ not a list item
+
+Same for angle brackets:
+
+\> not a block quote
+
+And hash signs:
+
+\# not a heading
+  \## not a subheading
+
+Text under a shortcut reference should be preserved verbatim:
+
+-   [two*three]
+-   [two\*three]
+-   [a\a]
+-   [a\\a]
+-   [a\\\a]
+-   [a_a\_a]
+
+**GFM:**
+
+Colon should be escaped in URLs:
+
+-   http\://user:password@host:port/path?key=value#fragment
+-   https\://user:password@host:port/path?key=value#fragment
+
+Double tildes should be \~~escaped\~~.
+
+Pipes should be escaped: \|
+
+**Commonmark:**
+
+Open angle bracket should be escaped:
+
+-   \<div>\</div>
+-   \<http\:google.com>

--- a/test/input/stringify-escape.output.nocommonmark.text
+++ b/test/input/stringify-escape.output.nocommonmark.text
@@ -1,0 +1,51 @@
+Characters that should be escaped in general:
+
+\\ \` \* \[ \_
+
+Characters that shouldn't:
+
+{}]()#+-.!>"$%',/:;=?@^~
+
+Ampersands are escaped only when they would otherwise start an entity:
+
+-   &amp;copycat &amp;amp; &amp;#x26
+-   But: &copycat; `&between;` &foo; & AT&T &c
+
+Open parenthesis should be escaped after a shortcut reference:
+
+[ref]\(text)
+
+Hyphen should be escaped at the beginning of a line:
+
+\- not a list item
+\- not a list item
+  \+ not a list item
+
+Same for angle brackets:
+
+\> not a block quote
+
+And hash signs:
+
+\# not a heading
+  \## not a subheading
+
+Text under a shortcut reference should be preserved verbatim:
+
+-   [two*three]
+-   [two\*three]
+-   [a\a]
+-   [a\\a]
+-   [a\\\a]
+-   [a_a\_a]
+
+**GFM:**
+
+Colon should be escaped in URLs:
+
+-   http&colon;//user:password@host:port/path?key=value#fragment
+-   https&colon;//user:password@host:port/path?key=value#fragment
+
+Double tildes should be \~~escaped\~~.
+
+Pipes should be escaped: \|

--- a/test/tree/backslash-escapes.commonmark.json
+++ b/test/tree/backslash-escapes.commonmark.json
@@ -51,7 +51,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -97,7 +97,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {
@@ -143,7 +143,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -189,7 +189,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -235,7 +235,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "{",
           "position": {
             "start": {
@@ -281,7 +281,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "}",
           "position": {
             "start": {
@@ -327,7 +327,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "[",
           "position": {
             "start": {
@@ -373,7 +373,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "]",
           "position": {
             "start": {
@@ -419,7 +419,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "(",
           "position": {
             "start": {
@@ -465,7 +465,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ")",
           "position": {
             "start": {
@@ -511,7 +511,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ">",
           "position": {
             "start": {
@@ -557,7 +557,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "#",
           "position": {
             "start": {
@@ -603,7 +603,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ".",
           "position": {
             "start": {
@@ -649,7 +649,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "!",
           "position": {
             "start": {
@@ -695,7 +695,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "+",
           "position": {
             "start": {
@@ -741,7 +741,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "-",
           "position": {
             "start": {
@@ -834,7 +834,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "|",
           "position": {
             "start": {
@@ -880,7 +880,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "~",
           "position": {
             "start": {
@@ -973,7 +973,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\"",
           "position": {
             "start": {
@@ -1019,7 +1019,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "$",
           "position": {
             "start": {
@@ -1065,7 +1065,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "%",
           "position": {
             "start": {
@@ -1111,7 +1111,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "&",
           "position": {
             "start": {
@@ -1157,7 +1157,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "'",
           "position": {
             "start": {
@@ -1203,7 +1203,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ",",
           "position": {
             "start": {
@@ -1249,7 +1249,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "/",
           "position": {
             "start": {
@@ -1295,7 +1295,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ":",
           "position": {
             "start": {
@@ -1341,7 +1341,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ";",
           "position": {
             "start": {
@@ -1387,7 +1387,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "<",
           "position": {
             "start": {
@@ -1433,7 +1433,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "=",
           "position": {
             "start": {
@@ -1479,7 +1479,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "?",
           "position": {
             "start": {
@@ -1525,7 +1525,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "@",
           "position": {
             "start": {
@@ -1571,7 +1571,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "^",
           "position": {
             "start": {
@@ -1617,8 +1617,7 @@
           }
         },
         {
-          "type": "escape",
-          "value": "\n",
+          "type": "break",
           "position": {
             "start": {
               "line": 71,
@@ -3601,7 +3600,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -3631,7 +3630,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -3662,7 +3661,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -3692,7 +3691,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -3723,7 +3722,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {
@@ -3753,7 +3752,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {

--- a/test/tree/backslash-escapes.json
+++ b/test/tree/backslash-escapes.json
@@ -51,7 +51,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -97,7 +97,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {
@@ -143,7 +143,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -189,7 +189,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -235,7 +235,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "{",
           "position": {
             "start": {
@@ -281,7 +281,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "}",
           "position": {
             "start": {
@@ -327,7 +327,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "[",
           "position": {
             "start": {
@@ -373,7 +373,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "]",
           "position": {
             "start": {
@@ -419,7 +419,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "(",
           "position": {
             "start": {
@@ -465,7 +465,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ")",
           "position": {
             "start": {
@@ -511,7 +511,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ">",
           "position": {
             "start": {
@@ -557,7 +557,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "#",
           "position": {
             "start": {
@@ -603,7 +603,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ".",
           "position": {
             "start": {
@@ -649,7 +649,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "!",
           "position": {
             "start": {
@@ -695,7 +695,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "+",
           "position": {
             "start": {
@@ -741,7 +741,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "-",
           "position": {
             "start": {
@@ -834,7 +834,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "|",
           "position": {
             "start": {
@@ -880,7 +880,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "~",
           "position": {
             "start": {
@@ -3361,7 +3361,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -3391,7 +3391,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -3422,7 +3422,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -3452,7 +3452,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -3483,7 +3483,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {
@@ -3513,7 +3513,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {

--- a/test/tree/backslash-escapes.nogfm.json
+++ b/test/tree/backslash-escapes.nogfm.json
@@ -51,7 +51,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -97,7 +97,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {
@@ -143,7 +143,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -189,7 +189,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -235,7 +235,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "{",
           "position": {
             "start": {
@@ -281,7 +281,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "}",
           "position": {
             "start": {
@@ -327,7 +327,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "[",
           "position": {
             "start": {
@@ -373,7 +373,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "]",
           "position": {
             "start": {
@@ -419,7 +419,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "(",
           "position": {
             "start": {
@@ -465,7 +465,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ")",
           "position": {
             "start": {
@@ -511,7 +511,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ">",
           "position": {
             "start": {
@@ -557,7 +557,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "#",
           "position": {
             "start": {
@@ -603,7 +603,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": ".",
           "position": {
             "start": {
@@ -649,7 +649,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "!",
           "position": {
             "start": {
@@ -695,7 +695,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "+",
           "position": {
             "start": {
@@ -741,7 +741,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "-",
           "position": {
             "start": {
@@ -3331,7 +3331,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -3361,7 +3361,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -3392,7 +3392,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -3422,7 +3422,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -3453,7 +3453,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {
@@ -3483,7 +3483,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "`",
           "position": {
             "start": {

--- a/test/tree/breaks-hard.commonmark.json
+++ b/test/tree/breaks-hard.commonmark.json
@@ -426,8 +426,7 @@
           }
         },
         {
-          "type": "escape",
-          "value": "\n",
+          "type": "break",
           "position": {
             "start": {
               "line": 15,
@@ -458,8 +457,7 @@
           }
         },
         {
-          "type": "escape",
-          "value": "\n",
+          "type": "break",
           "position": {
             "start": {
               "line": 16,

--- a/test/tree/breaks-hard.nogfm.commonmark.json
+++ b/test/tree/breaks-hard.nogfm.commonmark.json
@@ -426,8 +426,7 @@
           }
         },
         {
-          "type": "escape",
-          "value": "\n",
+          "type": "break",
           "position": {
             "start": {
               "line": 15,
@@ -458,8 +457,7 @@
           }
         },
         {
-          "type": "escape",
-          "value": "\n",
+          "type": "break",
           "position": {
             "start": {
               "line": 16,

--- a/test/tree/emphasis-escaped-final-marker.json
+++ b/test/tree/emphasis-escaped-final-marker.json
@@ -20,7 +20,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -66,7 +66,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -127,7 +127,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {
@@ -173,7 +173,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "_",
           "position": {
             "start": {

--- a/test/tree/escaped-angles.json
+++ b/test/tree/escaped-angles.json
@@ -5,7 +5,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": ">",
           "position": {
             "start": {

--- a/test/tree/links-reference-style.json
+++ b/test/tree/links-reference-style.json
@@ -298,7 +298,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "[",
               "position": {
                 "start": {
@@ -328,7 +328,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "]",
               "position": {
                 "start": {
@@ -1670,7 +1670,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "[",
           "position": {
             "start": {

--- a/test/tree/links-text-entity-delimiters.commonmark.json
+++ b/test/tree/links-text-entity-delimiters.commonmark.json
@@ -11,11 +11,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 1,
                   "column": 2
+                },
+                "end": {
+                  "line": 1,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 25
                 },
                 "end": {
                   "line": 1,
@@ -75,11 +90,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 3,
                   "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 25
                 },
                 "end": {
                   "line": 3,
@@ -235,11 +265,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 9,
                   "column": 2
+                },
+                "end": {
+                  "line": 9,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 25
                 },
                 "end": {
                   "line": 9,
@@ -299,11 +344,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 11,
                   "column": 2
+                },
+                "end": {
+                  "line": 11,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 11,
+                  "column": 25
                 },
                 "end": {
                   "line": 11,

--- a/test/tree/links-text-entity-delimiters.json
+++ b/test/tree/links-text-entity-delimiters.json
@@ -11,11 +11,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 1,
                   "column": 2
+                },
+                "end": {
+                  "line": 1,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 25
                 },
                 "end": {
                   "line": 1,
@@ -75,11 +90,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 3,
                   "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 25
                 },
                 "end": {
                   "line": 3,
@@ -235,11 +265,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 9,
                   "column": 2
+                },
+                "end": {
+                  "line": 9,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 25
                 },
                 "end": {
                   "line": 9,
@@ -299,11 +344,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 11,
                   "column": 2
+                },
+                "end": {
+                  "line": 11,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 11,
+                  "column": 25
                 },
                 "end": {
                   "line": 11,

--- a/test/tree/links-text-entity-delimiters.nogfm.json
+++ b/test/tree/links-text-entity-delimiters.nogfm.json
@@ -11,11 +11,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 1,
                   "column": 2
+                },
+                "end": {
+                  "line": 1,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 25
                 },
                 "end": {
                   "line": 1,
@@ -75,11 +90,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 3,
                   "column": 2
+                },
+                "end": {
+                  "line": 3,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 25
                 },
                 "end": {
                   "line": 3,
@@ -235,11 +265,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 9,
                   "column": 2
+                },
+                "end": {
+                  "line": 9,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 25
                 },
                 "end": {
                   "line": 9,
@@ -299,11 +344,26 @@
           "children": [
             {
               "type": "text",
-              "value": "Hello [world]!",
+              "value": "Hello [world]",
               "position": {
                 "start": {
                   "line": 11,
                   "column": 2
+                },
+                "end": {
+                  "line": 11,
+                  "column": 25
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "!",
+              "position": {
+                "start": {
+                  "line": 11,
+                  "column": 25
                 },
                 "end": {
                   "line": 11,

--- a/test/tree/links-text-escaped-delimiters.commonmark.json
+++ b/test/tree/links-text-escaped-delimiters.commonmark.json
@@ -25,7 +25,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "[",
               "position": {
                 "start": {
@@ -55,7 +55,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "]",
               "position": {
                 "start": {
@@ -149,7 +149,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "[",
               "position": {
                 "start": {
@@ -179,7 +179,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "]",
               "position": {
                 "start": {

--- a/test/tree/links-text-escaped-delimiters.json
+++ b/test/tree/links-text-escaped-delimiters.json
@@ -25,7 +25,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "[",
               "position": {
                 "start": {
@@ -55,7 +55,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "]",
               "position": {
                 "start": {
@@ -149,7 +149,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "[",
               "position": {
                 "start": {
@@ -179,7 +179,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "]",
               "position": {
                 "start": {

--- a/test/tree/links-text-escaped-delimiters.nogfm.json
+++ b/test/tree/links-text-escaped-delimiters.nogfm.json
@@ -25,7 +25,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "[",
               "position": {
                 "start": {
@@ -55,7 +55,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "]",
               "position": {
                 "start": {
@@ -149,7 +149,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "[",
               "position": {
                 "start": {
@@ -179,7 +179,7 @@
               }
             },
             {
-              "type": "escape",
+              "type": "text",
               "value": "]",
               "position": {
                 "start": {

--- a/test/tree/markdown-documentation-syntax.commonmark.json
+++ b/test/tree/markdown-documentation-syntax.commonmark.json
@@ -2144,7 +2144,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -2174,7 +2174,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {

--- a/test/tree/markdown-documentation-syntax.commonmark.pedantic.json
+++ b/test/tree/markdown-documentation-syntax.commonmark.pedantic.json
@@ -2144,7 +2144,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -2174,7 +2174,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {

--- a/test/tree/markdown-documentation-syntax.json
+++ b/test/tree/markdown-documentation-syntax.json
@@ -2144,7 +2144,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -2174,7 +2174,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {

--- a/test/tree/markdown-documentation-syntax.nogfm.commonmark.json
+++ b/test/tree/markdown-documentation-syntax.nogfm.commonmark.json
@@ -2149,7 +2149,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -2179,7 +2179,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {

--- a/test/tree/markdown-documentation-syntax.nogfm.commonmark.pedantic.json
+++ b/test/tree/markdown-documentation-syntax.nogfm.commonmark.pedantic.json
@@ -1813,7 +1813,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -1843,7 +1843,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {

--- a/test/tree/markdown-documentation-syntax.nogfm.json
+++ b/test/tree/markdown-documentation-syntax.nogfm.json
@@ -2149,7 +2149,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -2179,7 +2179,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {

--- a/test/tree/markdown-documentation-syntax.nogfm.pedantic.json
+++ b/test/tree/markdown-documentation-syntax.nogfm.pedantic.json
@@ -1813,7 +1813,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -1843,7 +1843,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {

--- a/test/tree/markdown-documentation-syntax.pedantic.json
+++ b/test/tree/markdown-documentation-syntax.pedantic.json
@@ -2144,7 +2144,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {
@@ -2174,7 +2174,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "*",
           "position": {
             "start": {

--- a/test/tree/not-a-link.json
+++ b/test/tree/not-a-link.json
@@ -5,7 +5,7 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "escape",
+          "type": "text",
           "value": "[",
           "position": {
             "start": {

--- a/test/tree/stringify-escape.output.commonmark.commonmark.json
+++ b/test/tree/stringify-escape.output.commonmark.commonmark.json
@@ -1,0 +1,2215 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Characters that should be escaped in general:",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 46
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 46
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "\\",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1
+            },
+            "end": {
+              "line": 3,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 3
+            },
+            "end": {
+              "line": 3,
+              "column": 4
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "`",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 4
+            },
+            "end": {
+              "line": 3,
+              "column": 6
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 6
+            },
+            "end": {
+              "line": 3,
+              "column": 7
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "*",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 7
+            },
+            "end": {
+              "line": 3,
+              "column": 9
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 9
+            },
+            "end": {
+              "line": 3,
+              "column": 10
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "[",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 10
+            },
+            "end": {
+              "line": 3,
+              "column": 12
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 12
+            },
+            "end": {
+              "line": 3,
+              "column": 13
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 13
+            },
+            "end": {
+              "line": 3,
+              "column": 15
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1
+        },
+        "end": {
+          "line": 3,
+          "column": 15
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Characters that shouldn't:",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1
+            },
+            "end": {
+              "line": 5,
+              "column": 27
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1
+        },
+        "end": {
+          "line": 5,
+          "column": 27
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "{}]()#+-.!>\"$%',/:;=?@^~",
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 1
+            },
+            "end": {
+              "line": 7,
+              "column": 25
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 7,
+          "column": 1
+        },
+        "end": {
+          "line": 7,
+          "column": 25
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Ampersands are escaped only when they would otherwise start an entity:",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1
+            },
+            "end": {
+              "line": 9,
+              "column": 71
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1
+        },
+        "end": {
+          "line": 9,
+          "column": 71
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "&",
+                  "position": {
+                    "start": {
+                      "line": 11,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 7
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "copycat ",
+                  "position": {
+                    "start": {
+                      "line": 11,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 15
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "&",
+                  "position": {
+                    "start": {
+                      "line": 11,
+                      "column": 15
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 17
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "amp; ",
+                  "position": {
+                    "start": {
+                      "line": 11,
+                      "column": 17
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 22
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "&",
+                  "position": {
+                    "start": {
+                      "line": 11,
+                      "column": 22
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 24
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "#x26",
+                  "position": {
+                    "start": {
+                      "line": 11,
+                      "column": 24
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 28
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 11,
+                  "column": 5
+                },
+                "end": {
+                  "line": 11,
+                  "column": 28
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1
+            },
+            "end": {
+              "line": 11,
+              "column": 28
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "But: &copycat; ",
+                  "position": {
+                    "start": {
+                      "line": 12,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 20
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "&between;",
+                  "position": {
+                    "start": {
+                      "line": 12,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 31
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": " &foo; & AT&T &c",
+                  "position": {
+                    "start": {
+                      "line": 12,
+                      "column": 31
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 47
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 12,
+                  "column": 5
+                },
+                "end": {
+                  "line": 12,
+                  "column": 47
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 12,
+              "column": 1
+            },
+            "end": {
+              "line": 12,
+              "column": 47
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1
+        },
+        "end": {
+          "line": 12,
+          "column": 47
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Open parenthesis should be escaped after a shortcut reference:",
+          "position": {
+            "start": {
+              "line": 14,
+              "column": 1
+            },
+            "end": {
+              "line": 14,
+              "column": 63
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 14,
+          "column": 1
+        },
+        "end": {
+          "line": 14,
+          "column": 63
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "ref",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "ref",
+              "position": {
+                "start": {
+                  "line": 16,
+                  "column": 2
+                },
+                "end": {
+                  "line": 16,
+                  "column": 5
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 16,
+              "column": 1
+            },
+            "end": {
+              "line": 16,
+              "column": 6
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "(",
+          "position": {
+            "start": {
+              "line": 16,
+              "column": 6
+            },
+            "end": {
+              "line": 16,
+              "column": 8
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "text)",
+          "position": {
+            "start": {
+              "line": 16,
+              "column": 8
+            },
+            "end": {
+              "line": 16,
+              "column": 13
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 16,
+          "column": 1
+        },
+        "end": {
+          "line": 16,
+          "column": 13
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Hyphen should be escaped at the beginning of a line:",
+          "position": {
+            "start": {
+              "line": 18,
+              "column": 1
+            },
+            "end": {
+              "line": 18,
+              "column": 53
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 18,
+          "column": 1
+        },
+        "end": {
+          "line": 18,
+          "column": 53
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "-",
+          "position": {
+            "start": {
+              "line": 20,
+              "column": 1
+            },
+            "end": {
+              "line": 20,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a list item\n",
+          "position": {
+            "start": {
+              "line": 20,
+              "column": 3
+            },
+            "end": {
+              "line": 21,
+              "column": 1
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "value": "-",
+          "position": {
+            "start": {
+              "line": 21,
+              "column": 1
+            },
+            "end": {
+              "line": 21,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a list item\n  ",
+          "position": {
+            "start": {
+              "line": 21,
+              "column": 3
+            },
+            "end": {
+              "line": 22,
+              "column": 3
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "value": "+",
+          "position": {
+            "start": {
+              "line": 22,
+              "column": 3
+            },
+            "end": {
+              "line": 22,
+              "column": 5
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a list item",
+          "position": {
+            "start": {
+              "line": 22,
+              "column": 5
+            },
+            "end": {
+              "line": 22,
+              "column": 21
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 20,
+          "column": 1
+        },
+        "end": {
+          "line": 22,
+          "column": 21
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Same for angle brackets:",
+          "position": {
+            "start": {
+              "line": 24,
+              "column": 1
+            },
+            "end": {
+              "line": 24,
+              "column": 25
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 24,
+          "column": 1
+        },
+        "end": {
+          "line": 24,
+          "column": 25
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": ">",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 1
+            },
+            "end": {
+              "line": 26,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a block quote",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 3
+            },
+            "end": {
+              "line": 26,
+              "column": 21
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 26,
+          "column": 1
+        },
+        "end": {
+          "line": 26,
+          "column": 21
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "And hash signs:",
+          "position": {
+            "start": {
+              "line": 28,
+              "column": 1
+            },
+            "end": {
+              "line": 28,
+              "column": 16
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 28,
+          "column": 1
+        },
+        "end": {
+          "line": 28,
+          "column": 16
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "#",
+          "position": {
+            "start": {
+              "line": 30,
+              "column": 1
+            },
+            "end": {
+              "line": 30,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a heading\n  ",
+          "position": {
+            "start": {
+              "line": 30,
+              "column": 3
+            },
+            "end": {
+              "line": 31,
+              "column": 3
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "value": "#",
+          "position": {
+            "start": {
+              "line": 31,
+              "column": 3
+            },
+            "end": {
+              "line": 31,
+              "column": 5
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "# not a subheading",
+          "position": {
+            "start": {
+              "line": 31,
+              "column": 5
+            },
+            "end": {
+              "line": 31,
+              "column": 23
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 30,
+          "column": 1
+        },
+        "end": {
+          "line": 31,
+          "column": 23
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Text under a shortcut reference should be preserved verbatim:",
+          "position": {
+            "start": {
+              "line": 33,
+              "column": 1
+            },
+            "end": {
+              "line": 33,
+              "column": 62
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 33,
+          "column": 1
+        },
+        "end": {
+          "line": 33,
+          "column": 62
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "two*three",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "two*three",
+                      "position": {
+                        "start": {
+                          "line": 35,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 35,
+                          "column": 15
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 35,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 35,
+                      "column": 16
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 35,
+                  "column": 5
+                },
+                "end": {
+                  "line": 35,
+                  "column": 16
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 35,
+              "column": 1
+            },
+            "end": {
+              "line": 35,
+              "column": 16
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "two\\*three",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "two",
+                      "position": {
+                        "start": {
+                          "line": 36,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 36,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "*",
+                      "position": {
+                        "start": {
+                          "line": 36,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 36,
+                          "column": 11
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "three",
+                      "position": {
+                        "start": {
+                          "line": 36,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 36,
+                          "column": 16
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 36,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 36,
+                      "column": 17
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 36,
+                  "column": 5
+                },
+                "end": {
+                  "line": 36,
+                  "column": 17
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 36,
+              "column": 1
+            },
+            "end": {
+              "line": 36,
+              "column": 17
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a\\a",
+                      "position": {
+                        "start": {
+                          "line": 37,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 37,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 37,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 37,
+                      "column": 10
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 37,
+                  "column": 5
+                },
+                "end": {
+                  "line": 37,
+                  "column": 10
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 37,
+              "column": 1
+            },
+            "end": {
+              "line": 37,
+              "column": 10
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a",
+                      "position": {
+                        "start": {
+                          "line": 38,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 38,
+                          "column": 7
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\",
+                      "position": {
+                        "start": {
+                          "line": 38,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 38,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "a",
+                      "position": {
+                        "start": {
+                          "line": 38,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 38,
+                          "column": 10
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 38,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 38,
+                      "column": 11
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 38,
+                  "column": 5
+                },
+                "end": {
+                  "line": 38,
+                  "column": 11
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 38,
+              "column": 1
+            },
+            "end": {
+              "line": 38,
+              "column": 11
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\\\\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a",
+                      "position": {
+                        "start": {
+                          "line": 39,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 39,
+                          "column": 7
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\",
+                      "position": {
+                        "start": {
+                          "line": 39,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 39,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\a",
+                      "position": {
+                        "start": {
+                          "line": 39,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 39,
+                          "column": 11
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 39,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 39,
+                      "column": 12
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 39,
+                  "column": 5
+                },
+                "end": {
+                  "line": 39,
+                  "column": 12
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 39,
+              "column": 1
+            },
+            "end": {
+              "line": 39,
+              "column": 12
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a_a\\_a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a_a",
+                      "position": {
+                        "start": {
+                          "line": 40,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 40,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "_",
+                      "position": {
+                        "start": {
+                          "line": 40,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 40,
+                          "column": 11
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "a",
+                      "position": {
+                        "start": {
+                          "line": 40,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 40,
+                          "column": 12
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 40,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 40,
+                      "column": 13
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 40,
+                  "column": 5
+                },
+                "end": {
+                  "line": 40,
+                  "column": 13
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 40,
+              "column": 1
+            },
+            "end": {
+              "line": 40,
+              "column": 13
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 35,
+          "column": 1
+        },
+        "end": {
+          "line": 40,
+          "column": 13
+        },
+        "indent": [
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "GFM:",
+              "position": {
+                "start": {
+                  "line": 42,
+                  "column": 3
+                },
+                "end": {
+                  "line": 42,
+                  "column": 7
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 42,
+              "column": 1
+            },
+            "end": {
+              "line": 42,
+              "column": 9
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 42,
+          "column": 1
+        },
+        "end": {
+          "line": 42,
+          "column": 9
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Colon should be escaped in URLs:",
+          "position": {
+            "start": {
+              "line": 44,
+              "column": 1
+            },
+            "end": {
+              "line": 44,
+              "column": 33
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 44,
+          "column": 1
+        },
+        "end": {
+          "line": 44,
+          "column": 33
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "http",
+                  "position": {
+                    "start": {
+                      "line": 46,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 46,
+                      "column": 9
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 46,
+                      "column": 9
+                    },
+                    "end": {
+                      "line": 46,
+                      "column": 11
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "//user:password@host:port/path?key=value#fragment",
+                  "position": {
+                    "start": {
+                      "line": 46,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 46,
+                      "column": 60
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 46,
+                  "column": 5
+                },
+                "end": {
+                  "line": 46,
+                  "column": 60
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 46,
+              "column": 1
+            },
+            "end": {
+              "line": 46,
+              "column": 60
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "https",
+                  "position": {
+                    "start": {
+                      "line": 47,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 47,
+                      "column": 10
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 47,
+                      "column": 10
+                    },
+                    "end": {
+                      "line": 47,
+                      "column": 12
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "//user:password@host:port/path?key=value#fragment",
+                  "position": {
+                    "start": {
+                      "line": 47,
+                      "column": 12
+                    },
+                    "end": {
+                      "line": 47,
+                      "column": 61
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 47,
+                  "column": 5
+                },
+                "end": {
+                  "line": 47,
+                  "column": 61
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 47,
+              "column": 1
+            },
+            "end": {
+              "line": 47,
+              "column": 61
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 46,
+          "column": 1
+        },
+        "end": {
+          "line": 47,
+          "column": 61
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Double tildes should be ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 1
+            },
+            "end": {
+              "line": 49,
+              "column": 25
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 25
+            },
+            "end": {
+              "line": 49,
+              "column": 27
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~escaped",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 27
+            },
+            "end": {
+              "line": 49,
+              "column": 35
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 35
+            },
+            "end": {
+              "line": 49,
+              "column": 37
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~.",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 37
+            },
+            "end": {
+              "line": 49,
+              "column": 39
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 49,
+          "column": 1
+        },
+        "end": {
+          "line": 49,
+          "column": 39
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Pipes should be escaped: ",
+          "position": {
+            "start": {
+              "line": 51,
+              "column": 1
+            },
+            "end": {
+              "line": 51,
+              "column": 26
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "|",
+          "position": {
+            "start": {
+              "line": 51,
+              "column": 26
+            },
+            "end": {
+              "line": 51,
+              "column": 28
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 51,
+          "column": 1
+        },
+        "end": {
+          "line": 51,
+          "column": 28
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "Commonmark:",
+              "position": {
+                "start": {
+                  "line": 53,
+                  "column": 3
+                },
+                "end": {
+                  "line": 53,
+                  "column": 14
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 53,
+              "column": 1
+            },
+            "end": {
+              "line": 53,
+              "column": 16
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 53,
+          "column": 1
+        },
+        "end": {
+          "line": 53,
+          "column": 16
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Open angle bracket should be escaped:",
+          "position": {
+            "start": {
+              "line": 55,
+              "column": 1
+            },
+            "end": {
+              "line": 55,
+              "column": 38
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 55,
+          "column": 1
+        },
+        "end": {
+          "line": 55,
+          "column": 38
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 57,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 57,
+                      "column": 7
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "div>",
+                  "position": {
+                    "start": {
+                      "line": 57,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 57,
+                      "column": 11
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 57,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 57,
+                      "column": 13
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "/div>",
+                  "position": {
+                    "start": {
+                      "line": 57,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 57,
+                      "column": 18
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 57,
+                  "column": 5
+                },
+                "end": {
+                  "line": 57,
+                  "column": 18
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 57,
+              "column": 1
+            },
+            "end": {
+              "line": 57,
+              "column": 18
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 58,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 58,
+                      "column": 7
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "http",
+                  "position": {
+                    "start": {
+                      "line": 58,
+                      "column": 7
+                    },
+                    "end": {
+                      "line": 58,
+                      "column": 11
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 58,
+                      "column": 11
+                    },
+                    "end": {
+                      "line": 58,
+                      "column": 13
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "google.com>",
+                  "position": {
+                    "start": {
+                      "line": 58,
+                      "column": 13
+                    },
+                    "end": {
+                      "line": 58,
+                      "column": 24
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 58,
+                  "column": 5
+                },
+                "end": {
+                  "line": 58,
+                  "column": 24
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 58,
+              "column": 1
+            },
+            "end": {
+              "line": 58,
+              "column": 24
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 57,
+          "column": 1
+        },
+        "end": {
+          "line": 58,
+          "column": 24
+        },
+        "indent": [
+          1
+        ]
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1
+    },
+    "end": {
+      "line": 59,
+      "column": 1
+    }
+  }
+}

--- a/test/tree/stringify-escape.output.nocommonmark.json
+++ b/test/tree/stringify-escape.output.nocommonmark.json
@@ -1,0 +1,1793 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Characters that should be escaped in general:",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 1
+            },
+            "end": {
+              "line": 1,
+              "column": 46
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1
+        },
+        "end": {
+          "line": 1,
+          "column": 46
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "\\",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1
+            },
+            "end": {
+              "line": 3,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 3
+            },
+            "end": {
+              "line": 3,
+              "column": 4
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "`",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 4
+            },
+            "end": {
+              "line": 3,
+              "column": 6
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 6
+            },
+            "end": {
+              "line": 3,
+              "column": 7
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "*",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 7
+            },
+            "end": {
+              "line": 3,
+              "column": 9
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 9
+            },
+            "end": {
+              "line": 3,
+              "column": 10
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "[",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 10
+            },
+            "end": {
+              "line": 3,
+              "column": 12
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 12
+            },
+            "end": {
+              "line": 3,
+              "column": 13
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 13
+            },
+            "end": {
+              "line": 3,
+              "column": 15
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1
+        },
+        "end": {
+          "line": 3,
+          "column": 15
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Characters that shouldn't:",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1
+            },
+            "end": {
+              "line": 5,
+              "column": 27
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1
+        },
+        "end": {
+          "line": 5,
+          "column": 27
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "{}]()#+-.!>\"$%',/:;=?@^~",
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 1
+            },
+            "end": {
+              "line": 7,
+              "column": 25
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 7,
+          "column": 1
+        },
+        "end": {
+          "line": 7,
+          "column": 25
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Ampersands are escaped only when they would otherwise start an entity:",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1
+            },
+            "end": {
+              "line": 9,
+              "column": 71
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1
+        },
+        "end": {
+          "line": 9,
+          "column": 71
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "&copycat &amp; &#x26",
+                  "position": {
+                    "start": {
+                      "line": 11,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 11,
+                      "column": 37
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 11,
+                  "column": 5
+                },
+                "end": {
+                  "line": 11,
+                  "column": 37
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1
+            },
+            "end": {
+              "line": 11,
+              "column": 37
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "But: &copycat; ",
+                  "position": {
+                    "start": {
+                      "line": 12,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 20
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "&between;",
+                  "position": {
+                    "start": {
+                      "line": 12,
+                      "column": 20
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 31
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": " &foo; & AT&T &c",
+                  "position": {
+                    "start": {
+                      "line": 12,
+                      "column": 31
+                    },
+                    "end": {
+                      "line": 12,
+                      "column": 47
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 12,
+                  "column": 5
+                },
+                "end": {
+                  "line": 12,
+                  "column": 47
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 12,
+              "column": 1
+            },
+            "end": {
+              "line": 12,
+              "column": 47
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1
+        },
+        "end": {
+          "line": 12,
+          "column": 47
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Open parenthesis should be escaped after a shortcut reference:",
+          "position": {
+            "start": {
+              "line": 14,
+              "column": 1
+            },
+            "end": {
+              "line": 14,
+              "column": 63
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 14,
+          "column": 1
+        },
+        "end": {
+          "line": 14,
+          "column": 63
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "ref",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "ref",
+              "position": {
+                "start": {
+                  "line": 16,
+                  "column": 2
+                },
+                "end": {
+                  "line": 16,
+                  "column": 5
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 16,
+              "column": 1
+            },
+            "end": {
+              "line": 16,
+              "column": 6
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "(",
+          "position": {
+            "start": {
+              "line": 16,
+              "column": 6
+            },
+            "end": {
+              "line": 16,
+              "column": 8
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "text)",
+          "position": {
+            "start": {
+              "line": 16,
+              "column": 8
+            },
+            "end": {
+              "line": 16,
+              "column": 13
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 16,
+          "column": 1
+        },
+        "end": {
+          "line": 16,
+          "column": 13
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Hyphen should be escaped at the beginning of a line:",
+          "position": {
+            "start": {
+              "line": 18,
+              "column": 1
+            },
+            "end": {
+              "line": 18,
+              "column": 53
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 18,
+          "column": 1
+        },
+        "end": {
+          "line": 18,
+          "column": 53
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "-",
+          "position": {
+            "start": {
+              "line": 20,
+              "column": 1
+            },
+            "end": {
+              "line": 20,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a list item\n",
+          "position": {
+            "start": {
+              "line": 20,
+              "column": 3
+            },
+            "end": {
+              "line": 21,
+              "column": 1
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "value": "-",
+          "position": {
+            "start": {
+              "line": 21,
+              "column": 1
+            },
+            "end": {
+              "line": 21,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a list item\n  ",
+          "position": {
+            "start": {
+              "line": 21,
+              "column": 3
+            },
+            "end": {
+              "line": 22,
+              "column": 3
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "value": "+",
+          "position": {
+            "start": {
+              "line": 22,
+              "column": 3
+            },
+            "end": {
+              "line": 22,
+              "column": 5
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a list item",
+          "position": {
+            "start": {
+              "line": 22,
+              "column": 5
+            },
+            "end": {
+              "line": 22,
+              "column": 21
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 20,
+          "column": 1
+        },
+        "end": {
+          "line": 22,
+          "column": 21
+        },
+        "indent": [
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Same for angle brackets:",
+          "position": {
+            "start": {
+              "line": 24,
+              "column": 1
+            },
+            "end": {
+              "line": 24,
+              "column": 25
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 24,
+          "column": 1
+        },
+        "end": {
+          "line": 24,
+          "column": 25
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": ">",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 1
+            },
+            "end": {
+              "line": 26,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a block quote",
+          "position": {
+            "start": {
+              "line": 26,
+              "column": 3
+            },
+            "end": {
+              "line": 26,
+              "column": 21
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 26,
+          "column": 1
+        },
+        "end": {
+          "line": 26,
+          "column": 21
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "And hash signs:",
+          "position": {
+            "start": {
+              "line": 28,
+              "column": 1
+            },
+            "end": {
+              "line": 28,
+              "column": 16
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 28,
+          "column": 1
+        },
+        "end": {
+          "line": 28,
+          "column": 16
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "#",
+          "position": {
+            "start": {
+              "line": 30,
+              "column": 1
+            },
+            "end": {
+              "line": 30,
+              "column": 3
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " not a heading\n  ",
+          "position": {
+            "start": {
+              "line": 30,
+              "column": 3
+            },
+            "end": {
+              "line": 31,
+              "column": 3
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "text",
+          "value": "#",
+          "position": {
+            "start": {
+              "line": 31,
+              "column": 3
+            },
+            "end": {
+              "line": 31,
+              "column": 5
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "# not a subheading",
+          "position": {
+            "start": {
+              "line": 31,
+              "column": 5
+            },
+            "end": {
+              "line": 31,
+              "column": 23
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 30,
+          "column": 1
+        },
+        "end": {
+          "line": 31,
+          "column": 23
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Text under a shortcut reference should be preserved verbatim:",
+          "position": {
+            "start": {
+              "line": 33,
+              "column": 1
+            },
+            "end": {
+              "line": 33,
+              "column": 62
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 33,
+          "column": 1
+        },
+        "end": {
+          "line": 33,
+          "column": 62
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "two*three",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "two*three",
+                      "position": {
+                        "start": {
+                          "line": 35,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 35,
+                          "column": 15
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 35,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 35,
+                      "column": 16
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 35,
+                  "column": 5
+                },
+                "end": {
+                  "line": 35,
+                  "column": 16
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 35,
+              "column": 1
+            },
+            "end": {
+              "line": 35,
+              "column": 16
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "two\\*three",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "two",
+                      "position": {
+                        "start": {
+                          "line": 36,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 36,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "*",
+                      "position": {
+                        "start": {
+                          "line": 36,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 36,
+                          "column": 11
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "three",
+                      "position": {
+                        "start": {
+                          "line": 36,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 36,
+                          "column": 16
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 36,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 36,
+                      "column": 17
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 36,
+                  "column": 5
+                },
+                "end": {
+                  "line": 36,
+                  "column": 17
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 36,
+              "column": 1
+            },
+            "end": {
+              "line": 36,
+              "column": 17
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a\\a",
+                      "position": {
+                        "start": {
+                          "line": 37,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 37,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 37,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 37,
+                      "column": 10
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 37,
+                  "column": 5
+                },
+                "end": {
+                  "line": 37,
+                  "column": 10
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 37,
+              "column": 1
+            },
+            "end": {
+              "line": 37,
+              "column": 10
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a",
+                      "position": {
+                        "start": {
+                          "line": 38,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 38,
+                          "column": 7
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\",
+                      "position": {
+                        "start": {
+                          "line": 38,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 38,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "a",
+                      "position": {
+                        "start": {
+                          "line": 38,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 38,
+                          "column": 10
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 38,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 38,
+                      "column": 11
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 38,
+                  "column": 5
+                },
+                "end": {
+                  "line": 38,
+                  "column": 11
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 38,
+              "column": 1
+            },
+            "end": {
+              "line": 38,
+              "column": 11
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\\\\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a",
+                      "position": {
+                        "start": {
+                          "line": 39,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 39,
+                          "column": 7
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\",
+                      "position": {
+                        "start": {
+                          "line": 39,
+                          "column": 7
+                        },
+                        "end": {
+                          "line": 39,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\a",
+                      "position": {
+                        "start": {
+                          "line": 39,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 39,
+                          "column": 11
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 39,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 39,
+                      "column": 12
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 39,
+                  "column": 5
+                },
+                "end": {
+                  "line": 39,
+                  "column": 12
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 39,
+              "column": 1
+            },
+            "end": {
+              "line": 39,
+              "column": 12
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a_a\\_a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a_a",
+                      "position": {
+                        "start": {
+                          "line": 40,
+                          "column": 6
+                        },
+                        "end": {
+                          "line": 40,
+                          "column": 9
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "_",
+                      "position": {
+                        "start": {
+                          "line": 40,
+                          "column": 9
+                        },
+                        "end": {
+                          "line": 40,
+                          "column": 11
+                        },
+                        "indent": []
+                      }
+                    },
+                    {
+                      "type": "text",
+                      "value": "a",
+                      "position": {
+                        "start": {
+                          "line": 40,
+                          "column": 11
+                        },
+                        "end": {
+                          "line": 40,
+                          "column": 12
+                        },
+                        "indent": []
+                      }
+                    }
+                  ],
+                  "position": {
+                    "start": {
+                      "line": 40,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 40,
+                      "column": 13
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 40,
+                  "column": 5
+                },
+                "end": {
+                  "line": 40,
+                  "column": 13
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 40,
+              "column": 1
+            },
+            "end": {
+              "line": 40,
+              "column": 13
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 35,
+          "column": 1
+        },
+        "end": {
+          "line": 40,
+          "column": 13
+        },
+        "indent": [
+          1,
+          1,
+          1,
+          1,
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "GFM:",
+              "position": {
+                "start": {
+                  "line": 42,
+                  "column": 3
+                },
+                "end": {
+                  "line": 42,
+                  "column": 7
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 42,
+              "column": 1
+            },
+            "end": {
+              "line": 42,
+              "column": 9
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 42,
+          "column": 1
+        },
+        "end": {
+          "line": 42,
+          "column": 9
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Colon should be escaped in URLs:",
+          "position": {
+            "start": {
+              "line": 44,
+              "column": 1
+            },
+            "end": {
+              "line": 44,
+              "column": 33
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 44,
+          "column": 1
+        },
+        "end": {
+          "line": 44,
+          "column": 33
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "http://user:password@host:port/path?key=value#fragment",
+                  "position": {
+                    "start": {
+                      "line": 46,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 46,
+                      "column": 65
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 46,
+                  "column": 5
+                },
+                "end": {
+                  "line": 46,
+                  "column": 65
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 46,
+              "column": 1
+            },
+            "end": {
+              "line": 46,
+              "column": 65
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "https://user:password@host:port/path?key=value#fragment",
+                  "position": {
+                    "start": {
+                      "line": 47,
+                      "column": 5
+                    },
+                    "end": {
+                      "line": 47,
+                      "column": 66
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 47,
+                  "column": 5
+                },
+                "end": {
+                  "line": 47,
+                  "column": 66
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 47,
+              "column": 1
+            },
+            "end": {
+              "line": 47,
+              "column": 66
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 46,
+          "column": 1
+        },
+        "end": {
+          "line": 47,
+          "column": 66
+        },
+        "indent": [
+          1
+        ]
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Double tildes should be ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 1
+            },
+            "end": {
+              "line": 49,
+              "column": 25
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 25
+            },
+            "end": {
+              "line": 49,
+              "column": 27
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~escaped",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 27
+            },
+            "end": {
+              "line": 49,
+              "column": 35
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 35
+            },
+            "end": {
+              "line": 49,
+              "column": 37
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~.",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 37
+            },
+            "end": {
+              "line": 49,
+              "column": 39
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 49,
+          "column": 1
+        },
+        "end": {
+          "line": 49,
+          "column": 39
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Pipes should be escaped: ",
+          "position": {
+            "start": {
+              "line": 51,
+              "column": 1
+            },
+            "end": {
+              "line": 51,
+              "column": 26
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "|",
+          "position": {
+            "start": {
+              "line": 51,
+              "column": 26
+            },
+            "end": {
+              "line": 51,
+              "column": 28
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 51,
+          "column": 1
+        },
+        "end": {
+          "line": 51,
+          "column": 28
+        },
+        "indent": []
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1
+    },
+    "end": {
+      "line": 52,
+      "column": 1
+    }
+  }
+}

--- a/test/tree/table-escaped-pipes.nooutput.commonmark.json
+++ b/test/tree/table-escaped-pipes.nooutput.commonmark.json
@@ -280,7 +280,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "|",
                   "position": {
                     "start": {
@@ -341,7 +341,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "|",
                   "position": {
                     "start": {
@@ -434,7 +434,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "\\",
                   "position": {
                     "start": {
@@ -480,7 +480,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "\\",
                   "position": {
                     "start": {
@@ -573,7 +573,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "\\",
                   "position": {
                     "start": {
@@ -588,7 +588,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "|",
                   "position": {
                     "start": {
@@ -649,7 +649,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "\\",
                   "position": {
                     "start": {
@@ -664,7 +664,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "|",
                   "position": {
                     "start": {

--- a/test/tree/table-escaped-pipes.nooutput.json
+++ b/test/tree/table-escaped-pipes.nooutput.json
@@ -280,7 +280,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "|",
                   "position": {
                     "start": {
@@ -341,7 +341,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "|",
                   "position": {
                     "start": {
@@ -434,7 +434,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "\\",
                   "position": {
                     "start": {
@@ -480,7 +480,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "\\",
                   "position": {
                     "start": {
@@ -573,7 +573,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "\\",
                   "position": {
                     "start": {
@@ -588,7 +588,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "|",
                   "position": {
                     "start": {
@@ -649,7 +649,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "\\",
                   "position": {
                     "start": {
@@ -664,7 +664,7 @@
                   }
                 },
                 {
-                  "type": "escape",
+                  "type": "text",
                   "value": "|",
                   "position": {
                     "start": {

--- a/test/tree/table-escaped-pipes.nooutput.nogfm.commonmark.json
+++ b/test/tree/table-escaped-pipes.nooutput.nogfm.commonmark.json
@@ -24,7 +24,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "|",
           "position": {
             "start": {
@@ -54,7 +54,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "|",
           "position": {
             "start": {
@@ -86,7 +86,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -116,7 +116,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -148,7 +148,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -163,7 +163,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "|",
           "position": {
             "start": {
@@ -193,7 +193,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -208,7 +208,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "|",
           "position": {
             "start": {

--- a/test/tree/table-escaped-pipes.nooutput.nogfm.json
+++ b/test/tree/table-escaped-pipes.nooutput.nogfm.json
@@ -25,7 +25,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -55,7 +55,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -87,7 +87,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {
@@ -117,7 +117,7 @@
           }
         },
         {
-          "type": "escape",
+          "type": "text",
           "value": "\\",
           "position": {
             "start": {


### PR DESCRIPTION
This patch changes the parser so that it constructs regular `text` nodes instead of `escape` nodes and changes the compiler so that it escapes characters all by itself.

As a result, AST is simplified (no more escape nodes) and compilation becomes more reliable (a plugin can safely insert asterisks into the tree and it won't affect the compiled Markdown in an unexpected way).

However, this is still a work in progress.

I decided to implement the absolutely simplest approach first — that is, to make stringifier escape _every_ escapable character. As @wooorm warned in https://github.com/wooorm/mdast/issues/71#issuecomment-143448370, this results in _a lot_ of backslashes in the output (for example, `npm run build-md` with this patch changes a lot of docs). Every single period is escaped. This issue is still to be addressed.

I open this PR for suggestions and feedback. Sorry it took me so long.

Close #71.