### PR TITLE
Improve parsing a URL in text

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -4070,7 +4070,8 @@ function tokenizeURL(eat, value, silent) {
     var match;
     var length;
     var queue;
-    var once;
+    var parenCount;
+    var nextCharacter;
     var now;
 
     if (!self.options.gfm) {
@@ -4098,6 +4099,7 @@ function tokenizeURL(eat, value, silent) {
     index = subvalue.length;
     length = value.length;
     queue = EMPTY;
+    parenCount = 0;
 
     while (index < length) {
         character = value.charAt(index);
@@ -4116,11 +4118,30 @@ function tokenizeURL(eat, value, silent) {
             character === C_PAREN_CLOSE ||
             character === C_BRACKET_CLOSE
         ) {
-            if (once) {
+            nextCharacter = value.charAt(index + 1);
+            if (
+                !nextCharacter ||
+                isWhiteSpace(nextCharacter)
+            ) {
                 break;
             }
+        }
 
-            once = true;
+        if (
+            character === C_PAREN_OPEN ||
+            character === C_BRACKET_OPEN
+        ) {
+            parenCount++;
+        }
+
+        if (
+            character === C_PAREN_CLOSE ||
+            character === C_BRACKET_CLOSE
+        ) {
+            parenCount--;
+            if (parenCount < 0) {
+                break;
+            }
         }
 
         queue += character;

--- a/test/input/auto-link-url.text
+++ b/test/input/auto-link-url.text
@@ -1,3 +1,5 @@
 This should be a link: http://example.com/hello-world.
 
+Also, subdomain should be a part of the link (http://foo.example.com/(hello[world])).
+
 So should this: mailto:foo@bar.com.

--- a/test/tree/auto-link-url-invalid.json
+++ b/test/tree/auto-link-url-invalid.json
@@ -98,26 +98,8 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "link",
-          "title": null,
-          "href": "http://,",
-          "children": [
-            {
-              "type": "text",
-              "value": "http://,",
-              "position": {
-                "start": {
-                  "line": 7,
-                  "column": 1
-                },
-                "end": {
-                  "line": 7,
-                  "column": 9
-                },
-                "indent": []
-              }
-            }
-          ],
+          "type": "text",
+          "value": "http://,",
           "position": {
             "start": {
               "line": 7,
@@ -147,26 +129,8 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "link",
-          "title": null,
-          "href": "https://:",
-          "children": [
-            {
-              "type": "text",
-              "value": "https://:",
-              "position": {
-                "start": {
-                  "line": 9,
-                  "column": 1
-                },
-                "end": {
-                  "line": 9,
-                  "column": 10
-                },
-                "indent": []
-              }
-            }
-          ],
+          "type": "text",
+          "value": "https://:",
           "position": {
             "start": {
               "line": 9,
@@ -227,26 +191,8 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "link",
-          "title": null,
-          "href": "http://\"",
-          "children": [
-            {
-              "type": "text",
-              "value": "http://\"",
-              "position": {
-                "start": {
-                  "line": 13,
-                  "column": 1
-                },
-                "end": {
-                  "line": 13,
-                  "column": 9
-                },
-                "indent": []
-              }
-            }
-          ],
+          "type": "text",
+          "value": "http://\"",
           "position": {
             "start": {
               "line": 13,
@@ -276,26 +222,8 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "link",
-          "title": null,
-          "href": "https://'",
-          "children": [
-            {
-              "type": "text",
-              "value": "https://'",
-              "position": {
-                "start": {
-                  "line": 15,
-                  "column": 1
-                },
-                "end": {
-                  "line": 15,
-                  "column": 10
-                },
-                "indent": []
-              }
-            }
-          ],
+          "type": "text",
+          "value": "https://'",
           "position": {
             "start": {
               "line": 15,
@@ -356,26 +284,8 @@
       "type": "paragraph",
       "children": [
         {
-          "type": "link",
-          "title": null,
-          "href": "http://]",
-          "children": [
-            {
-              "type": "text",
-              "value": "http://]",
-              "position": {
-                "start": {
-                  "line": 19,
-                  "column": 1
-                },
-                "end": {
-                  "line": 19,
-                  "column": 9
-                },
-                "indent": []
-              }
-            }
-          ],
+          "type": "text",
+          "value": "http://]",
           "position": {
             "start": {
               "line": 19,

--- a/test/tree/auto-link-url.json
+++ b/test/tree/auto-link-url.json
@@ -85,7 +85,7 @@
       "children": [
         {
           "type": "text",
-          "value": "So should this: ",
+          "value": "Also, subdomain should be a part of the link (",
           "position": {
             "start": {
               "line": 3,
@@ -93,6 +93,85 @@
             },
             "end": {
               "line": 3,
+              "column": 47
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "link",
+          "title": null,
+          "href": "http://foo.example.com/(hello[world])",
+          "children": [
+            {
+              "type": "text",
+              "value": "http://foo.example.com/(hello[world])",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 47
+                },
+                "end": {
+                  "line": 3,
+                  "column": 84
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 47
+            },
+            "end": {
+              "line": 3,
+              "column": 84
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ").",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 84
+            },
+            "end": {
+              "line": 3,
+              "column": 86
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1
+        },
+        "end": {
+          "line": 3,
+          "column": 86
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "So should this: ",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1
+            },
+            "end": {
+              "line": 5,
               "column": 17
             },
             "indent": []
@@ -108,11 +187,11 @@
               "value": "foo@bar.com",
               "position": {
                 "start": {
-                  "line": 3,
+                  "line": 5,
                   "column": 17
                 },
                 "end": {
-                  "line": 3,
+                  "line": 5,
                   "column": 28
                 },
                 "indent": []
@@ -121,11 +200,11 @@
           ],
           "position": {
             "start": {
-              "line": 3,
+              "line": 5,
               "column": 17
             },
             "end": {
-              "line": 3,
+              "line": 5,
               "column": 35
             },
             "indent": []
@@ -136,11 +215,11 @@
           "value": ".",
           "position": {
             "start": {
-              "line": 3,
+              "line": 5,
               "column": 35
             },
             "end": {
-              "line": 3,
+              "line": 5,
               "column": 36
             },
             "indent": []
@@ -149,11 +228,11 @@
       ],
       "position": {
         "start": {
-          "line": 3,
+          "line": 5,
           "column": 1
         },
         "end": {
-          "line": 3,
+          "line": 5,
           "column": 36
         },
         "indent": []
@@ -166,7 +245,7 @@
       "column": 1
     },
     "end": {
-      "line": 4,
+      "line": 6,
       "column": 1
     }
   }

--- a/test/tree/auto-link-url.nogfm.json
+++ b/test/tree/auto-link-url.nogfm.json
@@ -37,7 +37,7 @@
       "children": [
         {
           "type": "text",
-          "value": "So should this: mailto:foo@bar.com.",
+          "value": "Also, subdomain should be a part of the link (http://foo.example.com/(hello",
           "position": {
             "start": {
               "line": 3,
@@ -45,7 +45,55 @@
             },
             "end": {
               "line": 3,
-              "column": 36
+              "column": 76
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "world",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "world",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 77
+                },
+                "end": {
+                  "line": 3,
+                  "column": 82
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 76
+            },
+            "end": {
+              "line": 3,
+              "column": 83
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ")).",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 83
+            },
+            "end": {
+              "line": 3,
+              "column": 86
             },
             "indent": []
           }
@@ -58,6 +106,37 @@
         },
         "end": {
           "line": 3,
+          "column": 86
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "So should this: mailto:foo@bar.com.",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1
+            },
+            "end": {
+              "line": 5,
+              "column": 36
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1
+        },
+        "end": {
+          "line": 5,
           "column": 36
         },
         "indent": []
@@ -70,7 +149,7 @@
       "column": 1
     },
     "end": {
-      "line": 4,
+      "line": 6,
       "column": 1
     }
   }


### PR DESCRIPTION
Current implementation parsed following text

```markdown
http://foo.example.com
```

as such a following code.

```markdown
<http://foo.example>.com
```

Almost all people don't expect such a behavior, I fixed it.

