### PR TITLE
stringify: fix entities in shortcut and collapsed references

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -287,28 +287,44 @@ function encodeFactory(type) {
 }
 
 /**
- * Check if a string starts with HTML entity.
+ * Returns the length of HTML entity that is a prefix of
+ * the given string (excluding the ampersand), 0 if it
+ * does not start with an entity.
  *
  * @example
- *   startsWithEntity('&copycat') // true
- *   startsWithEntity('&foo &amp &bar') // false
+ *   entityPrefixLength('&copycat') // 4
+ *   entityPrefixLength('&foo &amp &bar') // 0
  *
- * @param {string} value - Value to check.
- * @return {boolean} - Whether `value` starts an entity.
+ * @param {string} value - Input string.
+ * @return {number} - Length of an entity.
  */
-function startsWithEntity(value) {
+function entityPrefixLength(value) {
     var prefix;
 
     /* istanbul ignore if - Currently also tested for at
      * implemention, but we keep it here because that’s
      * proper. */
     if (value.charAt(0) !== AMPERSAND) {
-        return false;
+        return 0;
     }
 
     prefix = value.split(AMPERSAND, 2).join(AMPERSAND);
 
-    return decode(prefix).length !== prefix.length;
+    return prefix.length - decode(prefix).length;
+}
+
+/**
+ * Checks if a string starts with HTML entity.
+ *
+ * @example
+ *   startsWithEntity('&copycat') // true
+ *   startsWithEntity('&foo &amp &bar') // false
+ *
+ * @param {string} value - Value to check.
+ * @return {number} - Whether `value` starts an entity.
+ */
+function startsWithEntity(value) {
+    return entityPrefixLength(value) > 0;
 }
 
 /**
@@ -812,6 +828,40 @@ compilerPrototype.setOptions = function (options) {
 
 compilerPrototype.enterLink = stateToggler('inLink', false);
 compilerPrototype.enterTable = stateToggler('inTable', false);
+
+/**
+ * Shortcut and collapsed link references need no escaping
+ * and encoding during the processing of child nodes (it
+ * must be implied from identifier).
+ *
+ * This toggler turns encoding and escaping off for shortcut
+ * and collapsed references.
+ *
+ * Implies `enterLink`.
+ *
+ * @param {Compiler} compiler - Compiler instance.
+ * @param {LinkReference} node - LinkReference node.
+ * @return {Function} - Exit state.
+ */
+compilerPrototype.enterLinkReference = function (compiler, node) {
+    var encode = compiler.encode;
+    var escape = compiler.escape;
+    var exitLink = compiler.enterLink();
+
+    if (
+        node.referenceType === 'shortcut' ||
+        node.referenceType === 'collapsed'
+    ) {
+        compiler.encode = compiler.escape = encodeNoop;
+        return function () {
+            compiler.encode = encode;
+            compiler.escape = escape;
+            exitLink();
+        };
+    } else {
+        return exitLink;
+    }
+};
 
 /**
  * Visit a node.
@@ -1809,23 +1859,25 @@ function label(node) {
 }
 
 /**
- * For shortcut reference links, the contents is also an
- * identifier, and for identifiers extra backslashes do
- * matter.
+ * For shortcut and collapsed reference links, the contents
+ * is also an identifier, so we need to restore the original
+ * encoding and escaping that were present in the source
+ * string.
  *
- * This function takes an escaped value from shortcut's children
- * and an identifier and removes extra backslashes.
+ * This function takes the unescaped & unencoded value from
+ * shortcut's child nodes and the identifier and encodes
+ * the former according to the latter.
  *
  * @example
- *   unescapeShortcutLinkReference('a\\*b', 'a*b')
- *   // 'a*b'
+ *   copyIdentifierEncoding('a*b', 'a\\*b*c')
+ *   // 'a\\*b*c'
  *
- * @param {string} value - Escaped and stringified link value.
- * @param {string} identifier - Link identifier, in one of its
- *   equivalent forms.
- * @return {string} - Link value with some characters unescaped.
+ * @param {string} value - Unescaped and unencoded stringified
+ *   link value.
+ * @param {string} identifier - Link identifier.
+ * @return {string} - Encoded link value.
  */
-function unescapeShortcutLinkReference(value, identifier) {
+function copyIdentifierEncoding(value, identifier) {
     var index = 0;
     var position = 0;
     var length = value.length;
@@ -1868,6 +1920,9 @@ function unescapeShortcutLinkReference(value, identifier) {
             position < count &&
             PUNCTUATION.test(identifier.charAt(position))
         ) {
+            if (identifier.charAt(position) === AMPERSAND) {
+                position += entityPrefixLength(identifier.slice(position));
+            }
             position += 1;
         }
 
@@ -1908,13 +1963,16 @@ function unescapeShortcutLinkReference(value, identifier) {
  */
 compilerPrototype.linkReference = function (node) {
     var self = this;
-    var exitLink = self.enterLink();
+    var exitLinkReference = self.enterLinkReference(self, node);
     var value = self.all(node).join(EMPTY);
 
-    exitLink();
+    exitLinkReference();
 
-    if (node.referenceType == 'shortcut') {
-        value = unescapeShortcutLinkReference(value, node.identifier);
+    if (
+        node.referenceType === 'shortcut' ||
+        node.referenceType === 'collapsed'
+    ) {
+        value = copyIdentifierEncoding(value, node.identifier);
     }
 
     return SQUARE_BRACKET_OPEN + value + SQUARE_BRACKET_CLOSE + label(node);

--- a/test/input/entities.output.entities.text
+++ b/test/input/entities.output.entities.text
@@ -43,3 +43,11 @@ Image Reference `alt`:
 ![AT&amp;T with entity][favicon], ![AT&amp;T with numeric entity][favicon], ![AT&amp;T without entity][favicon].
 
 [favicon]: http://att.com/fav.ico "ATT favicon"
+
+Shortcut and collapsed references:
+
+[foo&bar], [foo&bar][], [foo&amp;bar], [foo&amp;bar][].
+
+[foo&bar]: http://example.com
+
+[foo&amp;bar]: http://example.com

--- a/test/input/entities.output.entities=escape.text
+++ b/test/input/entities.output.entities=escape.text
@@ -43,3 +43,11 @@ Image Reference `alt`:
 ![AT&amp;T with entity][favicon], ![AT&amp;T with numeric entity][favicon], ![AT&amp;T without entity][favicon].
 
 [favicon]: http://att.com/fav.ico "ATT favicon"
+
+Shortcut and collapsed references:
+
+[foo&bar], [foo&bar][], [foo&amp;bar], [foo&amp;bar][].
+
+[foo&bar]: http://example.com
+
+[foo&amp;bar]: http://example.com

--- a/test/input/entities.output.entities=numbers.text
+++ b/test/input/entities.output.entities=numbers.text
@@ -43,3 +43,11 @@ Image Reference `alt`:
 ![AT&#x26;T with entity][favicon], ![AT&#x26;T with numeric entity][favicon], ![AT&#x26;T without entity][favicon].
 
 [favicon]: http://att.com/fav.ico "ATT favicon"
+
+Shortcut and collapsed references:
+
+[foo&bar], [foo&bar][], [foo&amp;bar], [foo&amp;bar][].
+
+[foo&bar]: http://example.com
+
+[foo&amp;bar]: http://example.com

--- a/test/input/entities.output.noentities.text
+++ b/test/input/entities.output.noentities.text
@@ -43,3 +43,11 @@ Image Reference `alt`:
 ![AT&T with entity][favicon], ![AT&T with numeric entity][favicon], ![AT&T without entity][favicon].
 
 [favicon]: http://att.com/fav.ico "ATT favicon"
+
+Shortcut and collapsed references:
+
+[foo&bar], [foo&bar][], [foo&amp;bar], [foo&amp;bar][].
+
+[foo&bar]: http://example.com
+
+[foo&amp;bar]: http://example.com

--- a/test/tree/entities.output.entities.json
+++ b/test/tree/entities.output.entities.json
@@ -1715,6 +1715,339 @@
         },
         "indent": []
       }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Shortcut and collapsed references:",
+          "position": {
+            "start": {
+              "line": 47,
+              "column": 1
+            },
+            "end": {
+              "line": 47,
+              "column": 35
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 47,
+          "column": 1
+        },
+        "end": {
+          "line": 47,
+          "column": 35
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "foo&bar",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo&bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 2
+                },
+                "end": {
+                  "line": 49,
+                  "column": 9
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 1
+            },
+            "end": {
+              "line": 49,
+              "column": 10
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 10
+            },
+            "end": {
+              "line": 49,
+              "column": 12
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&bar",
+          "referenceType": "collapsed",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo&bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 13
+                },
+                "end": {
+                  "line": 49,
+                  "column": 20
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 12
+            },
+            "end": {
+              "line": 49,
+              "column": 23
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 23
+            },
+            "end": {
+              "line": 49,
+              "column": 25
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&amp;bar",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 26
+                },
+                "end": {
+                  "line": 49,
+                  "column": 29
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "&",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 29
+                },
+                "end": {
+                  "line": 49,
+                  "column": 34
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 34
+                },
+                "end": {
+                  "line": 49,
+                  "column": 37
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 25
+            },
+            "end": {
+              "line": 49,
+              "column": 38
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 38
+            },
+            "end": {
+              "line": 49,
+              "column": 40
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&amp;bar",
+          "referenceType": "collapsed",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 41
+                },
+                "end": {
+                  "line": 49,
+                  "column": 44
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "&",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 44
+                },
+                "end": {
+                  "line": 49,
+                  "column": 49
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 49
+                },
+                "end": {
+                  "line": 49,
+                  "column": 52
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 40
+            },
+            "end": {
+              "line": 49,
+              "column": 55
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ".",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 55
+            },
+            "end": {
+              "line": 49,
+              "column": 56
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 49,
+          "column": 1
+        },
+        "end": {
+          "line": 49,
+          "column": 56
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "foo&bar",
+      "title": null,
+      "link": "http://example.com",
+      "position": {
+        "start": {
+          "line": 51,
+          "column": 1
+        },
+        "end": {
+          "line": 51,
+          "column": 30
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "foo&amp;bar",
+      "title": null,
+      "link": "http://example.com",
+      "position": {
+        "start": {
+          "line": 53,
+          "column": 1
+        },
+        "end": {
+          "line": 53,
+          "column": 34
+        },
+        "indent": []
+      }
     }
   ],
   "position": {
@@ -1723,7 +2056,7 @@
       "column": 1
     },
     "end": {
-      "line": 46,
+      "line": 54,
       "column": 1
     }
   }

--- a/test/tree/entities.output.entities=escape.json
+++ b/test/tree/entities.output.entities=escape.json
@@ -1685,6 +1685,339 @@
         },
         "indent": []
       }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Shortcut and collapsed references:",
+          "position": {
+            "start": {
+              "line": 47,
+              "column": 1
+            },
+            "end": {
+              "line": 47,
+              "column": 35
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 47,
+          "column": 1
+        },
+        "end": {
+          "line": 47,
+          "column": 35
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "foo&bar",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo&bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 2
+                },
+                "end": {
+                  "line": 49,
+                  "column": 9
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 1
+            },
+            "end": {
+              "line": 49,
+              "column": 10
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 10
+            },
+            "end": {
+              "line": 49,
+              "column": 12
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&bar",
+          "referenceType": "collapsed",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo&bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 13
+                },
+                "end": {
+                  "line": 49,
+                  "column": 20
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 12
+            },
+            "end": {
+              "line": 49,
+              "column": 23
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 23
+            },
+            "end": {
+              "line": 49,
+              "column": 25
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&amp;bar",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 26
+                },
+                "end": {
+                  "line": 49,
+                  "column": 29
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "&",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 29
+                },
+                "end": {
+                  "line": 49,
+                  "column": 34
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 34
+                },
+                "end": {
+                  "line": 49,
+                  "column": 37
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 25
+            },
+            "end": {
+              "line": 49,
+              "column": 38
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 38
+            },
+            "end": {
+              "line": 49,
+              "column": 40
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&amp;bar",
+          "referenceType": "collapsed",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 41
+                },
+                "end": {
+                  "line": 49,
+                  "column": 44
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "&",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 44
+                },
+                "end": {
+                  "line": 49,
+                  "column": 49
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 49
+                },
+                "end": {
+                  "line": 49,
+                  "column": 52
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 40
+            },
+            "end": {
+              "line": 49,
+              "column": 55
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ".",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 55
+            },
+            "end": {
+              "line": 49,
+              "column": 56
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 49,
+          "column": 1
+        },
+        "end": {
+          "line": 49,
+          "column": 56
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "foo&bar",
+      "title": null,
+      "link": "http://example.com",
+      "position": {
+        "start": {
+          "line": 51,
+          "column": 1
+        },
+        "end": {
+          "line": 51,
+          "column": 30
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "foo&amp;bar",
+      "title": null,
+      "link": "http://example.com",
+      "position": {
+        "start": {
+          "line": 53,
+          "column": 1
+        },
+        "end": {
+          "line": 53,
+          "column": 34
+        },
+        "indent": []
+      }
     }
   ],
   "position": {
@@ -1693,7 +2026,7 @@
       "column": 1
     },
     "end": {
-      "line": 46,
+      "line": 54,
       "column": 1
     }
   }

--- a/test/tree/entities.output.entities=numbers.json
+++ b/test/tree/entities.output.entities=numbers.json
@@ -1715,6 +1715,339 @@
         },
         "indent": []
       }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Shortcut and collapsed references:",
+          "position": {
+            "start": {
+              "line": 47,
+              "column": 1
+            },
+            "end": {
+              "line": 47,
+              "column": 35
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 47,
+          "column": 1
+        },
+        "end": {
+          "line": 47,
+          "column": 35
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "foo&bar",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo&bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 2
+                },
+                "end": {
+                  "line": 49,
+                  "column": 9
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 1
+            },
+            "end": {
+              "line": 49,
+              "column": 10
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 10
+            },
+            "end": {
+              "line": 49,
+              "column": 12
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&bar",
+          "referenceType": "collapsed",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo&bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 13
+                },
+                "end": {
+                  "line": 49,
+                  "column": 20
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 12
+            },
+            "end": {
+              "line": 49,
+              "column": 23
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 23
+            },
+            "end": {
+              "line": 49,
+              "column": 25
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&amp;bar",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 26
+                },
+                "end": {
+                  "line": 49,
+                  "column": 29
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "&",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 29
+                },
+                "end": {
+                  "line": 49,
+                  "column": 34
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 34
+                },
+                "end": {
+                  "line": 49,
+                  "column": 37
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 25
+            },
+            "end": {
+              "line": 49,
+              "column": 38
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 38
+            },
+            "end": {
+              "line": 49,
+              "column": 40
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&amp;bar",
+          "referenceType": "collapsed",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 41
+                },
+                "end": {
+                  "line": 49,
+                  "column": 44
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "&",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 44
+                },
+                "end": {
+                  "line": 49,
+                  "column": 49
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 49
+                },
+                "end": {
+                  "line": 49,
+                  "column": 52
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 40
+            },
+            "end": {
+              "line": 49,
+              "column": 55
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ".",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 55
+            },
+            "end": {
+              "line": 49,
+              "column": 56
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 49,
+          "column": 1
+        },
+        "end": {
+          "line": 49,
+          "column": 56
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "foo&bar",
+      "title": null,
+      "link": "http://example.com",
+      "position": {
+        "start": {
+          "line": 51,
+          "column": 1
+        },
+        "end": {
+          "line": 51,
+          "column": 30
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "foo&amp;bar",
+      "title": null,
+      "link": "http://example.com",
+      "position": {
+        "start": {
+          "line": 53,
+          "column": 1
+        },
+        "end": {
+          "line": 53,
+          "column": 34
+        },
+        "indent": []
+      }
     }
   ],
   "position": {
@@ -1723,7 +2056,7 @@
       "column": 1
     },
     "end": {
-      "line": 46,
+      "line": 54,
       "column": 1
     }
   }

--- a/test/tree/entities.output.noentities.json
+++ b/test/tree/entities.output.noentities.json
@@ -1505,6 +1505,339 @@
         },
         "indent": []
       }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Shortcut and collapsed references:",
+          "position": {
+            "start": {
+              "line": 47,
+              "column": 1
+            },
+            "end": {
+              "line": 47,
+              "column": 35
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 47,
+          "column": 1
+        },
+        "end": {
+          "line": 47,
+          "column": 35
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "foo&bar",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo&bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 2
+                },
+                "end": {
+                  "line": 49,
+                  "column": 9
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 1
+            },
+            "end": {
+              "line": 49,
+              "column": 10
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 10
+            },
+            "end": {
+              "line": 49,
+              "column": 12
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&bar",
+          "referenceType": "collapsed",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo&bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 13
+                },
+                "end": {
+                  "line": 49,
+                  "column": 20
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 12
+            },
+            "end": {
+              "line": 49,
+              "column": 23
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 23
+            },
+            "end": {
+              "line": 49,
+              "column": 25
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&amp;bar",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 26
+                },
+                "end": {
+                  "line": 49,
+                  "column": 29
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "&",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 29
+                },
+                "end": {
+                  "line": 49,
+                  "column": 34
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 34
+                },
+                "end": {
+                  "line": 49,
+                  "column": 37
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 25
+            },
+            "end": {
+              "line": 49,
+              "column": 38
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", ",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 38
+            },
+            "end": {
+              "line": 49,
+              "column": 40
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "foo&amp;bar",
+          "referenceType": "collapsed",
+          "children": [
+            {
+              "type": "text",
+              "value": "foo",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 41
+                },
+                "end": {
+                  "line": 49,
+                  "column": 44
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "&",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 44
+                },
+                "end": {
+                  "line": 49,
+                  "column": 49
+                },
+                "indent": []
+              }
+            },
+            {
+              "type": "text",
+              "value": "bar",
+              "position": {
+                "start": {
+                  "line": 49,
+                  "column": 49
+                },
+                "end": {
+                  "line": 49,
+                  "column": 52
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 40
+            },
+            "end": {
+              "line": 49,
+              "column": 55
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ".",
+          "position": {
+            "start": {
+              "line": 49,
+              "column": 55
+            },
+            "end": {
+              "line": 49,
+              "column": 56
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 49,
+          "column": 1
+        },
+        "end": {
+          "line": 49,
+          "column": 56
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "foo&bar",
+      "title": null,
+      "link": "http://example.com",
+      "position": {
+        "start": {
+          "line": 51,
+          "column": 1
+        },
+        "end": {
+          "line": 51,
+          "column": 30
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "definition",
+      "identifier": "foo&amp;bar",
+      "title": null,
+      "link": "http://example.com",
+      "position": {
+        "start": {
+          "line": 53,
+          "column": 1
+        },
+        "end": {
+          "line": 53,
+          "column": 34
+        },
+        "indent": []
+      }
     }
   ],
   "position": {
@@ -1513,7 +1846,7 @@
       "column": 1
     },
     "end": {
-      "line": 46,
+      "line": 54,
       "column": 1
     }
   }


### PR DESCRIPTION
This patch fixes #141.

Previously `unescapeShortcutLinkReference` was called only for shortcut references (hence the name), and it was reverting some of escaping that was done before. This patch removes the unnecessary work and expands `unescapeShortcutLinkReference` to HTML entities as well as collapsed references.