### PR TITLE
Do not escape emphasis markers in words

### DIFF
--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -29,6 +29,7 @@ module.exports = {
     'stringify': {
         'gfm': true,
         'commonmark': false,
+        'pedantic': false,
         'entities': 'false',
         'setext': false,
         'closeAtx': false,

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -110,6 +110,16 @@ var TICK = '`';
 var TILDE = '~';
 var UNDERSCORE = '_';
 
+/**
+ * Check whether `character` is alphanumeric.
+ *
+ * @param {string} character - Single character to check.
+ * @return {boolean} - Whether `character` is alphanumeric.
+ */
+function isAlphanumeric(character) {
+    return /\w/.test(character) && character !== UNDERSCORE;
+}
+
 /*
  * Entities.
  */
@@ -409,6 +419,7 @@ function escapeFactory(options) {
         var self = this;
         var gfm = options.gfm;
         var commonmark = options.commonmark;
+        var pedantic = options.pedantic;
         var siblings = parent && parent.children;
         var index = siblings && siblings.indexOf(node);
         var prev = siblings && siblings[index - 1];
@@ -419,6 +430,8 @@ function escapeFactory(options) {
         var escaped = queue;
         var afterNewLine;
         var character;
+        var wordCharBefore;
+        var wordCharAfter;
 
         if (prev) {
             afterNewLine = prev.type === 'text' && /\n\s*$/.test(prev.value);
@@ -434,7 +447,20 @@ function escapeFactory(options) {
                 character === TICK ||
                 character === ASTERISK ||
                 character === SQUARE_BRACKET_OPEN ||
-                character === UNDERSCORE ||
+                (
+                    character === UNDERSCORE &&
+                    /*
+                     * Delegate leading/trailing underscores
+                     * to the multinode version below.
+                     */
+                    0 < position &&
+                    position < length - 1 &&
+                    (
+                        pedantic ||
+                        !isAlphanumeric(value.charAt(position - 1)) ||
+                        !isAlphanumeric(value.charAt(position + 1))
+                    )
+                ) ||
                 (self.inLink && character === SQUARE_BRACKET_CLOSE) ||
                 (
                     gfm &&
@@ -620,6 +646,58 @@ function escapeFactory(options) {
                 next.value.charAt(0) === TILDE
             ) {
                 escaped.splice(escaped.length - 1, 0, BACKSLASH);
+            }
+
+            /*
+             * Escape underscores, but not mid-word (unless
+             * in pedantic mode).
+             */
+
+            wordCharBefore = (
+                prev &&
+                prev.type === 'text' &&
+                isAlphanumeric(prev.value.slice(-1))
+            );
+
+            wordCharAfter = (
+                next &&
+                next.type === 'text' &&
+                isAlphanumeric(next.value.charAt(0))
+            );
+
+            if (length <= 1) {
+                if (
+                    value === UNDERSCORE &&
+                    (
+                        pedantic ||
+                        !wordCharBefore ||
+                        !wordCharAfter
+                    )
+                ) {
+                    escaped.unshift(BACKSLASH);
+                }
+            } else {
+                if (
+                    value.charAt(0) === UNDERSCORE &&
+                    (
+                        pedantic ||
+                        !wordCharBefore ||
+                        !isAlphanumeric(value.charAt(1))
+                    )
+                ) {
+                    escaped.unshift(BACKSLASH);
+                }
+
+                if (
+                    value.slice(-1) === UNDERSCORE &&
+                    (
+                        pedantic ||
+                        !wordCharAfter ||
+                        !isAlphanumeric(value.slice(-2)[0])
+                    )
+                ) {
+                    escaped.splice(escaped.length - 1, 0, BACKSLASH);
+                }
             }
         }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1259,7 +1259,8 @@ describe('fixtures', function () {
                 var parse = possibilities[key];
                 var stringify = extend({}, fixture.stringify, {
                     'gfm': parse.gfm,
-                    'commonmark': parse.commonmark
+                    'commonmark': parse.commonmark,
+                    'pedantic': parse.pedantic
                 });
                 var initialClean = !parse.position;
                 var node;
@@ -1277,7 +1278,7 @@ describe('fixtures', function () {
 
                     compare(node, trees[mapping[key]], false, initialClean);
 
-                    markdown = remark.stringify(node, stringify);
+                    markdown = remark.stringify(clone(node), stringify);
                 });
 
                 if (output !== false) {

--- a/test/input/stringify-escape.output.commonmark.text
+++ b/test/input/stringify-escape.output.commonmark.text
@@ -1,10 +1,12 @@
 Characters that should be escaped in general:
 
-\\ \` \* \[ \_
+\\ \` \* \[
 
 Characters that shouldn't:
 
 {}]()#+-.!>"$%',/:;=?@^~
+
+Underscores are \_escaped\_ unless they appear in_the_middle_of_a_word.
 
 Ampersands are escaped only when they would otherwise start an entity:
 

--- a/test/input/stringify-escape.output.nogfm.commonmark.text
+++ b/test/input/stringify-escape.output.nogfm.commonmark.text
@@ -1,10 +1,12 @@
 Characters that should be escaped in general:
 
-\\ \` \* \[ \_
+\\ \` \* \[
 
 Characters that shouldn't:
 
 {}]()#+-.!>"$%',/:;=?@^~
+
+Underscores are \_escaped\_ unless they appear in_the_middle_of_a_word.
 
 Ampersands are escaped only when they would otherwise start an entity:
 

--- a/test/input/stringify-escape.output.noposition.pedantic.text
+++ b/test/input/stringify-escape.output.noposition.pedantic.text
@@ -1,12 +1,12 @@
 Characters that should be escaped in general:
 
-\\ \` \* \[
+\\ \` \* \[ \_
 
 Characters that shouldn't:
 
 {}]()#+-.!>"$%',/:;=?@^~
 
-Underscores are \_escaped\_ unless they appear in_the_middle_of_a_word.
+Underscores are always \_escaped\_, even when they appear in\_the\_middle\_of\_a\_word.
 
 Ampersands are escaped only when they would otherwise start an entity:
 
@@ -43,30 +43,30 @@ Text under a shortcut reference should be preserved verbatim:
 
 **GFM:**
 
-Colon should not be escaped in URLs:
+Colon should be escaped in URLs:
 
--   http://user:password@host:port/path?key=value#fragment
--   https://user:password@host:port/path?key=value#fragment
+-   http&#x3A;//user:password@host:port/path?key=value#fragment
+-   https&#x3A;//user:password@host:port/path?key=value#fragment
 
-Double tildes should not be ~~escaped~~.
-Nor here: foo~~.
+Double tildes should be \~~escaped\~~.
+And here: foo\~~.
 
 Pipes should not be escaped here: |
 
 | here   | they     |
 | ------ | -------- |
-| should | nei|ther |
+| should | tho\|ugh |
 
-Nor here:
+And here:
 
 | here   | they   |
-| ------ | ------ |
+\| ---- \| ----- \|
 | should | though |
 
-Nor here:
+And here:
 
 here   | they
-\----- | ------
+\---- \| ------
 should | though
 
 **Commonmark:**
@@ -74,4 +74,4 @@ should | though
 Open angle bracket should be escaped:
 
 -   &lt;div>&lt;/div>
--   &lt;http:google.com>
+-   &lt;http&#x3A;google.com>

--- a/test/input/stringify-escape.output.pedantic.text
+++ b/test/input/stringify-escape.output.pedantic.text
@@ -1,12 +1,12 @@
 Characters that should be escaped in general:
 
-\\ \` \* \[
+\\ \` \* \[ \_
 
 Characters that shouldn't:
 
 {}]()#+-.!>"$%',/:;=?@^~
 
-Underscores are \_escaped\_ unless they appear in_the_middle_of_a_word.
+Underscores are always \_escaped\_, even when they appear in\_the\_middle\_of\_a\_word.
 
 Ampersands are escaped only when they would otherwise start an entity:
 
@@ -43,30 +43,30 @@ Text under a shortcut reference should be preserved verbatim:
 
 **GFM:**
 
-Colon should not be escaped in URLs:
+Colon should be escaped in URLs:
 
--   http://user:password@host:port/path?key=value#fragment
--   https://user:password@host:port/path?key=value#fragment
+-   http&#x3A;//user:password@host:port/path?key=value#fragment
+-   https&#x3A;//user:password@host:port/path?key=value#fragment
 
-Double tildes should not be ~~escaped~~.
-Nor here: foo~~.
+Double tildes should be \~~escaped\~~.
+And here: foo\~~.
 
 Pipes should not be escaped here: |
 
 | here   | they     |
 | ------ | -------- |
-| should | nei|ther |
+| should | tho\|ugh |
 
-Nor here:
+And here:
 
 | here   | they   |
-| ------ | ------ |
+\| ---- \| ----- \|
 | should | though |
 
-Nor here:
+And here:
 
 here   | they
-\----- | ------
+\---- \| ------
 should | though
 
 **Commonmark:**
@@ -74,4 +74,4 @@ should | though
 Open angle bracket should be escaped:
 
 -   &lt;div>&lt;/div>
--   &lt;http:google.com>
+-   &lt;http&#x3A;google.com>

--- a/test/input/stringify-escape.output.text
+++ b/test/input/stringify-escape.output.text
@@ -1,10 +1,12 @@
 Characters that should be escaped in general:
 
-\\ \` \* \[ \_
+\\ \` \* \[
 
 Characters that shouldn't:
 
 {}]()#+-.!>"$%',/:;=?@^~
+
+Underscores are \_escaped\_ unless they appear in_the_middle_of_a_word.
 
 Ampersands are escaped only when they would otherwise start an entity:
 

--- a/test/input/stringify-escape.text
+++ b/test/input/stringify-escape.text
@@ -1,10 +1,12 @@
 Characters that should be escaped in general:
 
-\\ \` \* \[ \_
+\\ \` \* \[
 
 Characters that shouldn't:
 
 {}]()#+-.!>"$%',/:;=?@^~
+
+Underscores are \_escaped\_ unless they appear in_the_middle_of_a_word.
 
 Ampersands are escaped only when they would otherwise start an entity:
 

--- a/test/tree/stringify-escape.commonmark.json
+++ b/test/tree/stringify-escape.commonmark.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,115 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in_the_middle_of_a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +354,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +369,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +400,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "indent": []
                   }
@@ -348,14 +417,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "indent": []
                   }
@@ -365,14 +434,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "indent": []
                   }
@@ -382,14 +451,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "indent": []
                   }
@@ -399,14 +468,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "indent": []
                   }
@@ -416,14 +485,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +515,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +540,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "indent": []
                   }
@@ -488,14 +557,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "indent": []
                   }
@@ -505,14 +574,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "indent": []
                   }
@@ -522,14 +591,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "indent": []
                   }
@@ -539,14 +608,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "indent": []
                   }
@@ -556,14 +625,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 37,
-                      "offset": 253
+                      "offset": 323
                     },
                     "indent": []
                   }
@@ -571,14 +640,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 37,
-                  "offset": 253
+                  "offset": 323
                 },
                 "indent": []
               }
@@ -586,14 +655,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 37,
-              "offset": 253
+              "offset": 323
             },
             "indent": []
           }
@@ -611,14 +680,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 5,
-                      "offset": 258
+                      "offset": 328
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "indent": []
                   }
@@ -628,14 +697,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "indent": []
                   }
@@ -645,14 +714,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 43,
-                      "offset": 296
+                      "offset": 366
                     },
                     "indent": []
                   }
@@ -660,14 +729,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 13,
+                  "line": 15,
                   "column": 5,
-                  "offset": 258
+                  "offset": 328
                 },
                 "end": {
-                  "line": 13,
+                  "line": 15,
                   "column": 43,
-                  "offset": 296
+                  "offset": 366
                 },
                 "indent": []
               }
@@ -675,14 +744,14 @@
           ],
           "position": {
             "start": {
-              "line": 13,
+              "line": 15,
               "column": 1,
-              "offset": 254
+              "offset": 324
             },
             "end": {
-              "line": 13,
+              "line": 15,
               "column": 43,
-              "offset": 296
+              "offset": 366
             },
             "indent": []
           }
@@ -690,14 +759,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 13,
+          "line": 15,
           "column": 43,
-          "offset": 296
+          "offset": 366
         },
         "indent": [
           1,
@@ -713,14 +782,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 15,
+              "line": 17,
               "column": 1,
-              "offset": 298
+              "offset": 368
             },
             "end": {
-              "line": 15,
+              "line": 17,
               "column": 63,
-              "offset": 360
+              "offset": 430
             },
             "indent": []
           }
@@ -728,14 +797,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 17,
           "column": 1,
-          "offset": 298
+          "offset": 368
         },
         "end": {
-          "line": 15,
+          "line": 17,
           "column": 63,
-          "offset": 360
+          "offset": 430
         },
         "indent": []
       }
@@ -753,14 +822,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 17,
+                  "line": 19,
                   "column": 2,
-                  "offset": 363
+                  "offset": 433
                 },
                 "end": {
-                  "line": 17,
+                  "line": 19,
                   "column": 5,
-                  "offset": 366
+                  "offset": 436
                 },
                 "indent": []
               }
@@ -768,14 +837,14 @@
           ],
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 1,
-              "offset": 362
+              "offset": 432
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "indent": []
           }
@@ -785,14 +854,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "indent": []
           }
@@ -802,14 +871,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 13,
-              "offset": 374
+              "offset": 444
             },
             "indent": []
           }
@@ -817,14 +886,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 19,
           "column": 1,
-          "offset": 362
+          "offset": 432
         },
         "end": {
-          "line": 17,
+          "line": 19,
           "column": 13,
-          "offset": 374
+          "offset": 444
         },
         "indent": []
       }
@@ -837,14 +906,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 19,
+              "line": 21,
               "column": 1,
-              "offset": 376
+              "offset": 446
             },
             "end": {
-              "line": 19,
+              "line": 21,
               "column": 53,
-              "offset": 428
+              "offset": 498
             },
             "indent": []
           }
@@ -852,14 +921,14 @@
       ],
       "position": {
         "start": {
-          "line": 19,
+          "line": 21,
           "column": 1,
-          "offset": 376
+          "offset": 446
         },
         "end": {
-          "line": 19,
+          "line": 21,
           "column": 53,
-          "offset": 428
+          "offset": 498
         },
         "indent": []
       }
@@ -872,14 +941,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 430
+              "offset": 500
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "indent": []
           }
@@ -889,14 +958,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "indent": [
               1
@@ -908,14 +977,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -925,14 +994,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "indent": [
               1
@@ -944,14 +1013,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "indent": []
           }
@@ -961,14 +1030,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 21,
-              "offset": 488
+              "offset": 558
             },
             "indent": []
           }
@@ -976,14 +1045,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 23,
           "column": 1,
-          "offset": 430
+          "offset": 500
         },
         "end": {
-          "line": 23,
+          "line": 25,
           "column": 21,
-          "offset": 488
+          "offset": 558
         },
         "indent": [
           1,
@@ -999,14 +1068,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 1,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 25,
+              "line": 27,
               "column": 25,
-              "offset": 514
+              "offset": 584
             },
             "indent": []
           }
@@ -1014,14 +1083,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 27,
           "column": 1,
-          "offset": 490
+          "offset": 560
         },
         "end": {
-          "line": 25,
+          "line": 27,
           "column": 25,
-          "offset": 514
+          "offset": 584
         },
         "indent": []
       }
@@ -1034,14 +1103,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 1,
-              "offset": 516
+              "offset": 586
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "indent": []
           }
@@ -1051,14 +1120,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 21,
-              "offset": 536
+              "offset": 606
             },
             "indent": []
           }
@@ -1066,14 +1135,14 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 29,
           "column": 1,
-          "offset": 516
+          "offset": 586
         },
         "end": {
-          "line": 27,
+          "line": 29,
           "column": 21,
-          "offset": 536
+          "offset": 606
         },
         "indent": []
       }
@@ -1086,14 +1155,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 29,
+              "line": 31,
               "column": 1,
-              "offset": 538
+              "offset": 608
             },
             "end": {
-              "line": 29,
+              "line": 31,
               "column": 16,
-              "offset": 553
+              "offset": 623
             },
             "indent": []
           }
@@ -1101,14 +1170,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 31,
           "column": 1,
-          "offset": 538
+          "offset": 608
         },
         "end": {
-          "line": 29,
+          "line": 31,
           "column": 16,
-          "offset": 553
+          "offset": 623
         },
         "indent": []
       }
@@ -1121,14 +1190,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 1,
-              "offset": 555
+              "offset": 625
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1138,14 +1207,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "indent": [
               1
@@ -1157,14 +1226,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "indent": []
           }
@@ -1174,14 +1243,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 23,
-              "offset": 594
+              "offset": 664
             },
             "indent": []
           }
@@ -1189,14 +1258,14 @@
       ],
       "position": {
         "start": {
-          "line": 31,
+          "line": 33,
           "column": 1,
-          "offset": 555
+          "offset": 625
         },
         "end": {
-          "line": 32,
+          "line": 34,
           "column": 23,
-          "offset": 594
+          "offset": 664
         },
         "indent": [
           1
@@ -1211,14 +1280,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 1,
-              "offset": 596
+              "offset": 666
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 62,
-              "offset": 657
+              "offset": 727
             },
             "indent": []
           }
@@ -1226,14 +1295,14 @@
       ],
       "position": {
         "start": {
-          "line": 34,
+          "line": 36,
           "column": 1,
-          "offset": 596
+          "offset": 666
         },
         "end": {
-          "line": 34,
+          "line": 36,
           "column": 62,
-          "offset": 657
+          "offset": 727
         },
         "indent": []
       }
@@ -1262,14 +1331,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 664
+                          "offset": 734
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 15,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1277,14 +1346,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 663
+                      "offset": 733
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 16,
-                      "offset": 674
+                      "offset": 744
                     },
                     "indent": []
                   }
@@ -1292,14 +1361,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 663
+                  "offset": 733
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 16,
-                  "offset": 674
+                  "offset": 744
                 },
                 "indent": []
               }
@@ -1307,14 +1376,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 659
+              "offset": 729
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 16,
-              "offset": 674
+              "offset": 744
             },
             "indent": []
           }
@@ -1337,14 +1406,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1354,14 +1423,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "indent": []
                       }
@@ -1371,14 +1440,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 16,
-                          "offset": 690
+                          "offset": 760
                         },
                         "indent": []
                       }
@@ -1386,14 +1455,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 679
+                      "offset": 749
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 17,
-                      "offset": 691
+                      "offset": 761
                     },
                     "indent": []
                   }
@@ -1401,14 +1470,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 679
+                  "offset": 749
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 17,
-                  "offset": 691
+                  "offset": 761
                 },
                 "indent": []
               }
@@ -1416,14 +1485,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 675
+              "offset": 745
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 17,
-              "offset": 691
+              "offset": 761
             },
             "indent": []
           }
@@ -1446,14 +1515,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 697
+                          "offset": 767
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 700
+                          "offset": 770
                         },
                         "indent": []
                       }
@@ -1461,14 +1530,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 696
+                      "offset": 766
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 10,
-                      "offset": 701
+                      "offset": 771
                     },
                     "indent": []
                   }
@@ -1476,14 +1545,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 696
+                  "offset": 766
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 10,
-                  "offset": 701
+                  "offset": 771
                 },
                 "indent": []
               }
@@ -1491,14 +1560,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 692
+              "offset": 762
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 10,
-              "offset": 701
+              "offset": 771
             },
             "indent": []
           }
@@ -1521,14 +1590,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1538,14 +1607,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1555,14 +1624,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 10,
-                          "offset": 711
+                          "offset": 781
                         },
                         "indent": []
                       }
@@ -1570,14 +1639,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 706
+                      "offset": 776
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 11,
-                      "offset": 712
+                      "offset": 782
                     },
                     "indent": []
                   }
@@ -1585,14 +1654,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 706
+                  "offset": 776
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 11,
-                  "offset": 712
+                  "offset": 782
                 },
                 "indent": []
               }
@@ -1600,14 +1669,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 11,
-              "offset": 712
+              "offset": 782
             },
             "indent": []
           }
@@ -1630,14 +1699,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 718
+                          "offset": 788
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "indent": []
                       }
@@ -1647,14 +1716,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "indent": []
                       }
@@ -1664,14 +1733,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 723
+                          "offset": 793
                         },
                         "indent": []
                       }
@@ -1679,14 +1748,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 717
+                      "offset": 787
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 12,
-                      "offset": 724
+                      "offset": 794
                     },
                     "indent": []
                   }
@@ -1694,14 +1763,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 717
+                  "offset": 787
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 12,
-                  "offset": 724
+                  "offset": 794
                 },
                 "indent": []
               }
@@ -1709,14 +1778,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 713
+              "offset": 783
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 12,
-              "offset": 724
+              "offset": 794
             },
             "indent": []
           }
@@ -1739,14 +1808,14 @@
                       "value": "a_a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 6,
-                          "offset": 730
+                          "offset": 800
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 9,
-                          "offset": 733
+                          "offset": 803
                         },
                         "indent": []
                       }
@@ -1756,14 +1825,14 @@
                       "value": "_",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 9,
-                          "offset": 733
+                          "offset": 803
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "indent": []
                       }
@@ -1773,14 +1842,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 12,
-                          "offset": 736
+                          "offset": 806
                         },
                         "indent": []
                       }
@@ -1788,14 +1857,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 41,
+                      "line": 43,
                       "column": 5,
-                      "offset": 729
+                      "offset": 799
                     },
                     "end": {
-                      "line": 41,
+                      "line": 43,
                       "column": 13,
-                      "offset": 737
+                      "offset": 807
                     },
                     "indent": []
                   }
@@ -1803,14 +1872,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
+                  "line": 43,
                   "column": 5,
-                  "offset": 729
+                  "offset": 799
                 },
                 "end": {
-                  "line": 41,
+                  "line": 43,
                   "column": 13,
-                  "offset": 737
+                  "offset": 807
                 },
                 "indent": []
               }
@@ -1818,14 +1887,14 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 43,
               "column": 1,
-              "offset": 725
+              "offset": 795
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 13,
-              "offset": 737
+              "offset": 807
             },
             "indent": []
           }
@@ -1833,14 +1902,14 @@
       ],
       "position": {
         "start": {
-          "line": 36,
+          "line": 38,
           "column": 1,
-          "offset": 659
+          "offset": 729
         },
         "end": {
-          "line": 41,
+          "line": 43,
           "column": 13,
-          "offset": 737
+          "offset": 807
         },
         "indent": [
           1,
@@ -1862,14 +1931,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 43,
+                  "line": 45,
                   "column": 3,
-                  "offset": 741
+                  "offset": 811
                 },
                 "end": {
-                  "line": 43,
+                  "line": 45,
                   "column": 7,
-                  "offset": 745
+                  "offset": 815
                 },
                 "indent": []
               }
@@ -1877,14 +1946,14 @@
           ],
           "position": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 1,
-              "offset": 739
+              "offset": 809
             },
             "end": {
-              "line": 43,
+              "line": 45,
               "column": 9,
-              "offset": 747
+              "offset": 817
             },
             "indent": []
           }
@@ -1892,14 +1961,14 @@
       ],
       "position": {
         "start": {
-          "line": 43,
+          "line": 45,
           "column": 1,
-          "offset": 739
+          "offset": 809
         },
         "end": {
-          "line": 43,
+          "line": 45,
           "column": 9,
-          "offset": 747
+          "offset": 817
         },
         "indent": []
       }
@@ -1912,14 +1981,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 45,
+              "line": 47,
               "column": 1,
-              "offset": 749
+              "offset": 819
             },
             "end": {
-              "line": 45,
+              "line": 47,
               "column": 33,
-              "offset": 781
+              "offset": 851
             },
             "indent": []
           }
@@ -1927,14 +1996,14 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 47,
           "column": 1,
-          "offset": 749
+          "offset": 819
         },
         "end": {
-          "line": 45,
+          "line": 47,
           "column": 33,
-          "offset": 781
+          "offset": 851
         },
         "indent": []
       }
@@ -1958,14 +2027,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 787
+                      "offset": 857
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 9,
-                      "offset": 791
+                      "offset": 861
                     },
                     "indent": []
                   }
@@ -1975,14 +2044,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 9,
-                      "offset": 791
+                      "offset": 861
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 11,
-                      "offset": 793
+                      "offset": 863
                     },
                     "indent": []
                   }
@@ -1992,14 +2061,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 11,
-                      "offset": 793
+                      "offset": 863
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 842
+                      "offset": 912
                     },
                     "indent": []
                   }
@@ -2007,14 +2076,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 787
+                  "offset": 857
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 842
+                  "offset": 912
                 },
                 "indent": []
               }
@@ -2022,14 +2091,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 783
+              "offset": 853
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 842
+              "offset": 912
             },
             "indent": []
           }
@@ -2047,14 +2116,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 5,
-                      "offset": 847
+                      "offset": 917
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 10,
-                      "offset": 852
+                      "offset": 922
                     },
                     "indent": []
                   }
@@ -2064,14 +2133,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 10,
-                      "offset": 852
+                      "offset": 922
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 12,
-                      "offset": 854
+                      "offset": 924
                     },
                     "indent": []
                   }
@@ -2081,14 +2150,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 12,
-                      "offset": 854
+                      "offset": 924
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 61,
-                      "offset": 903
+                      "offset": 973
                     },
                     "indent": []
                   }
@@ -2096,14 +2165,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 48,
+                  "line": 50,
                   "column": 5,
-                  "offset": 847
+                  "offset": 917
                 },
                 "end": {
-                  "line": 48,
+                  "line": 50,
                   "column": 61,
-                  "offset": 903
+                  "offset": 973
                 },
                 "indent": []
               }
@@ -2111,14 +2180,14 @@
           ],
           "position": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 1,
-              "offset": 843
+              "offset": 913
             },
             "end": {
-              "line": 48,
+              "line": 50,
               "column": 61,
-              "offset": 903
+              "offset": 973
             },
             "indent": []
           }
@@ -2136,14 +2205,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 5,
-                      "offset": 908
+                      "offset": 978
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "indent": []
                   }
@@ -2153,14 +2222,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "indent": []
                   }
@@ -2170,14 +2239,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 65,
-                      "offset": 968
+                      "offset": 1038
                     },
                     "indent": []
                   }
@@ -2185,14 +2254,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 51,
                   "column": 5,
-                  "offset": 908
+                  "offset": 978
                 },
                 "end": {
-                  "line": 49,
+                  "line": 51,
                   "column": 65,
-                  "offset": 968
+                  "offset": 1038
                 },
                 "indent": []
               }
@@ -2200,14 +2269,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 904
+              "offset": 974
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 65,
-              "offset": 968
+              "offset": 1038
             },
             "indent": []
           }
@@ -2225,14 +2294,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 5,
-                      "offset": 973
+                      "offset": 1043
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "indent": []
                   }
@@ -2242,14 +2311,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "indent": []
                   }
@@ -2259,14 +2328,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 66,
-                      "offset": 1034
+                      "offset": 1104
                     },
                     "indent": []
                   }
@@ -2274,14 +2343,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 50,
+                  "line": 52,
                   "column": 5,
-                  "offset": 973
+                  "offset": 1043
                 },
                 "end": {
-                  "line": 50,
+                  "line": 52,
                   "column": 66,
-                  "offset": 1034
+                  "offset": 1104
                 },
                 "indent": []
               }
@@ -2289,14 +2358,14 @@
           ],
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 1,
-              "offset": 969
+              "offset": 1039
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 66,
-              "offset": 1034
+              "offset": 1104
             },
             "indent": []
           }
@@ -2304,14 +2373,14 @@
       ],
       "position": {
         "start": {
-          "line": 47,
+          "line": 49,
           "column": 1,
-          "offset": 783
+          "offset": 853
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 66,
-          "offset": 1034
+          "offset": 1104
         },
         "indent": [
           1,
@@ -2328,14 +2397,14 @@
           "value": "Double tildes should be ",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 1036
+              "offset": 1106
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "indent": []
           }
@@ -2345,14 +2414,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "indent": []
           }
@@ -2362,14 +2431,14 @@
           "value": "~escaped",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "indent": []
           }
@@ -2379,14 +2448,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "indent": []
           }
@@ -2396,14 +2465,14 @@
           "value": "~.\nAnd here: foo~~.",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "end": {
-              "line": 53,
+              "line": 55,
               "column": 17,
-              "offset": 1091
+              "offset": 1161
             },
             "indent": [
               1
@@ -2413,14 +2482,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 1036
+          "offset": 1106
         },
         "end": {
-          "line": 53,
+          "line": 55,
           "column": 17,
-          "offset": 1091
+          "offset": 1161
         },
         "indent": [
           1
@@ -2435,14 +2504,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 55,
+              "line": 57,
               "column": 1,
-              "offset": 1093
+              "offset": 1163
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 36,
-              "offset": 1128
+              "offset": 1198
             },
             "indent": []
           }
@@ -2450,14 +2519,14 @@
       ],
       "position": {
         "start": {
-          "line": 55,
+          "line": 57,
           "column": 1,
-          "offset": 1093
+          "offset": 1163
         },
         "end": {
-          "line": 55,
+          "line": 57,
           "column": 36,
-          "offset": 1128
+          "offset": 1198
         },
         "indent": []
       }
@@ -2480,14 +2549,14 @@
                   "value": "here",
                   "position": {
                     "start": {
-                      "line": 57,
+                      "line": 59,
                       "column": 3,
-                      "offset": 1132
+                      "offset": 1202
                     },
                     "end": {
-                      "line": 57,
+                      "line": 59,
                       "column": 7,
-                      "offset": 1136
+                      "offset": 1206
                     },
                     "indent": []
                   }
@@ -2495,14 +2564,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 57,
+                  "line": 59,
                   "column": 3,
-                  "offset": 1132
+                  "offset": 1202
                 },
                 "end": {
-                  "line": 57,
+                  "line": 59,
                   "column": 9,
-                  "offset": 1138
+                  "offset": 1208
                 },
                 "indent": []
               }
@@ -2515,14 +2584,14 @@
                   "value": "they",
                   "position": {
                     "start": {
-                      "line": 57,
+                      "line": 59,
                       "column": 12,
-                      "offset": 1141
+                      "offset": 1211
                     },
                     "end": {
-                      "line": 57,
+                      "line": 59,
                       "column": 16,
-                      "offset": 1145
+                      "offset": 1215
                     },
                     "indent": []
                   }
@@ -2530,14 +2599,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 57,
+                  "line": 59,
                   "column": 12,
-                  "offset": 1141
+                  "offset": 1211
                 },
                 "end": {
-                  "line": 57,
+                  "line": 59,
                   "column": 20,
-                  "offset": 1149
+                  "offset": 1219
                 },
                 "indent": []
               }
@@ -2545,14 +2614,14 @@
           ],
           "position": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 57,
+              "line": 59,
               "column": 22,
-              "offset": 1151
+              "offset": 1221
             },
             "indent": []
           }
@@ -2568,14 +2637,14 @@
                   "value": "should",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 3,
-                      "offset": 1176
+                      "offset": 1246
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 9,
-                      "offset": 1182
+                      "offset": 1252
                     },
                     "indent": []
                   }
@@ -2583,14 +2652,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 59,
+                  "line": 61,
                   "column": 3,
-                  "offset": 1176
+                  "offset": 1246
                 },
                 "end": {
-                  "line": 59,
+                  "line": 61,
                   "column": 9,
-                  "offset": 1182
+                  "offset": 1252
                 },
                 "indent": []
               }
@@ -2603,14 +2672,14 @@
                   "value": "tho",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 12,
-                      "offset": 1185
+                      "offset": 1255
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 15,
-                      "offset": 1188
+                      "offset": 1258
                     },
                     "indent": []
                   }
@@ -2620,14 +2689,14 @@
                   "value": "|",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 15,
-                      "offset": 1188
+                      "offset": 1258
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 17,
-                      "offset": 1190
+                      "offset": 1260
                     },
                     "indent": []
                   }
@@ -2637,14 +2706,14 @@
                   "value": "ugh",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 17,
-                      "offset": 1190
+                      "offset": 1260
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 20,
-                      "offset": 1193
+                      "offset": 1263
                     },
                     "indent": []
                   }
@@ -2652,14 +2721,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 59,
+                  "line": 61,
                   "column": 12,
-                  "offset": 1185
+                  "offset": 1255
                 },
                 "end": {
-                  "line": 59,
+                  "line": 61,
                   "column": 20,
-                  "offset": 1193
+                  "offset": 1263
                 },
                 "indent": []
               }
@@ -2667,14 +2736,14 @@
           ],
           "position": {
             "start": {
-              "line": 59,
+              "line": 61,
               "column": 1,
-              "offset": 1174
+              "offset": 1244
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 22,
-              "offset": 1195
+              "offset": 1265
             },
             "indent": []
           }
@@ -2682,14 +2751,14 @@
       ],
       "position": {
         "start": {
-          "line": 57,
+          "line": 59,
           "column": 1,
-          "offset": 1130
+          "offset": 1200
         },
         "end": {
-          "line": 59,
+          "line": 61,
           "column": 22,
-          "offset": 1195
+          "offset": 1265
         },
         "indent": [
           1,
@@ -2705,14 +2774,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1197
+              "offset": 1267
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 10,
-              "offset": 1206
+              "offset": 1276
             },
             "indent": []
           }
@@ -2720,14 +2789,14 @@
       ],
       "position": {
         "start": {
-          "line": 61,
+          "line": 63,
           "column": 1,
-          "offset": 1197
+          "offset": 1267
         },
         "end": {
-          "line": 61,
+          "line": 63,
           "column": 10,
-          "offset": 1206
+          "offset": 1276
         },
         "indent": []
       }
@@ -2740,14 +2809,14 @@
           "value": "| here   | they   |\n",
           "position": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 1,
-              "offset": 1208
+              "offset": 1278
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "indent": [
               1
@@ -2759,14 +2828,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "indent": []
           }
@@ -2776,14 +2845,14 @@
           "value": " ---- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "indent": []
           }
@@ -2793,14 +2862,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "indent": []
           }
@@ -2810,14 +2879,14 @@
           "value": " ----- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "indent": []
           }
@@ -2827,14 +2896,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "indent": []
           }
@@ -2844,14 +2913,14 @@
           "value": "\n| should | though |",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "end": {
-              "line": 65,
+              "line": 67,
               "column": 20,
-              "offset": 1267
+              "offset": 1337
             },
             "indent": [
               1
@@ -2861,14 +2930,14 @@
       ],
       "position": {
         "start": {
-          "line": 63,
+          "line": 65,
           "column": 1,
-          "offset": 1208
+          "offset": 1278
         },
         "end": {
-          "line": 65,
+          "line": 67,
           "column": 20,
-          "offset": 1267
+          "offset": 1337
         },
         "indent": [
           1,
@@ -2884,14 +2953,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1269
+              "offset": 1339
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 10,
-              "offset": 1278
+              "offset": 1348
             },
             "indent": []
           }
@@ -2899,14 +2968,14 @@
       ],
       "position": {
         "start": {
-          "line": 67,
+          "line": 69,
           "column": 1,
-          "offset": 1269
+          "offset": 1339
         },
         "end": {
-          "line": 67,
+          "line": 69,
           "column": 10,
-          "offset": 1278
+          "offset": 1348
         },
         "indent": []
       }
@@ -2919,14 +2988,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 69,
+              "line": 71,
               "column": 1,
-              "offset": 1280
+              "offset": 1350
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "indent": [
               1
@@ -2938,14 +3007,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "indent": []
           }
@@ -2955,14 +3024,14 @@
           "value": "--- ",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "indent": []
           }
@@ -2972,14 +3041,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "indent": []
           }
@@ -2989,14 +3058,14 @@
           "value": " ------\nshould | though",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "end": {
-              "line": 71,
+              "line": 73,
               "column": 16,
-              "offset": 1325
+              "offset": 1395
             },
             "indent": [
               1
@@ -3006,14 +3075,14 @@
       ],
       "position": {
         "start": {
-          "line": 69,
+          "line": 71,
           "column": 1,
-          "offset": 1280
+          "offset": 1350
         },
         "end": {
-          "line": 71,
+          "line": 73,
           "column": 16,
-          "offset": 1325
+          "offset": 1395
         },
         "indent": [
           1,
@@ -3032,14 +3101,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 73,
+                  "line": 75,
                   "column": 3,
-                  "offset": 1329
+                  "offset": 1399
                 },
                 "end": {
-                  "line": 73,
+                  "line": 75,
                   "column": 14,
-                  "offset": 1340
+                  "offset": 1410
                 },
                 "indent": []
               }
@@ -3047,14 +3116,14 @@
           ],
           "position": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 1,
-              "offset": 1327
+              "offset": 1397
             },
             "end": {
-              "line": 73,
+              "line": 75,
               "column": 16,
-              "offset": 1342
+              "offset": 1412
             },
             "indent": []
           }
@@ -3062,14 +3131,14 @@
       ],
       "position": {
         "start": {
-          "line": 73,
+          "line": 75,
           "column": 1,
-          "offset": 1327
+          "offset": 1397
         },
         "end": {
-          "line": 73,
+          "line": 75,
           "column": 16,
-          "offset": 1342
+          "offset": 1412
         },
         "indent": []
       }
@@ -3082,14 +3151,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1344
+              "offset": 1414
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 38,
-              "offset": 1381
+              "offset": 1451
             },
             "indent": []
           }
@@ -3097,14 +3166,14 @@
       ],
       "position": {
         "start": {
-          "line": 75,
+          "line": 77,
           "column": 1,
-          "offset": 1344
+          "offset": 1414
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 38,
-          "offset": 1381
+          "offset": 1451
         },
         "indent": []
       }
@@ -3128,14 +3197,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 5,
-                      "offset": 1387
+                      "offset": 1457
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 7,
-                      "offset": 1389
+                      "offset": 1459
                     },
                     "indent": []
                   }
@@ -3145,14 +3214,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 7,
-                      "offset": 1389
+                      "offset": 1459
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "indent": []
                   }
@@ -3162,14 +3231,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 13,
-                      "offset": 1395
+                      "offset": 1465
                     },
                     "indent": []
                   }
@@ -3179,14 +3248,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 13,
-                      "offset": 1395
+                      "offset": 1465
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 18,
-                      "offset": 1400
+                      "offset": 1470
                     },
                     "indent": []
                   }
@@ -3194,14 +3263,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 77,
+                  "line": 79,
                   "column": 5,
-                  "offset": 1387
+                  "offset": 1457
                 },
                 "end": {
-                  "line": 77,
+                  "line": 79,
                   "column": 18,
-                  "offset": 1400
+                  "offset": 1470
                 },
                 "indent": []
               }
@@ -3209,14 +3278,14 @@
           ],
           "position": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 1,
-              "offset": 1383
+              "offset": 1453
             },
             "end": {
-              "line": 77,
+              "line": 79,
               "column": 18,
-              "offset": 1400
+              "offset": 1470
             },
             "indent": []
           }
@@ -3234,292 +3303,80 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 78,
+                      "line": 80,
                       "column": 5,
-                      "offset": 1405
+                      "offset": 1475
                     },
                     "end": {
-                      "line": 78,
+                      "line": 80,
                       "column": 7,
-                      "offset": 1407
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "http",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 7,
-                      "offset": 1407
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 11,
-                      "offset": 1411
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 11,
-                      "offset": 1411
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 13,
-                      "offset": 1413
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "google.com>",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 13,
-                      "offset": 1413
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 24,
-                      "offset": 1424
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 78,
-                  "column": 5,
-                  "offset": 1405
-                },
-                "end": {
-                  "line": 78,
-                  "column": 24,
-                  "offset": 1424
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 78,
-              "column": 1,
-              "offset": 1401
-            },
-            "end": {
-              "line": 78,
-              "column": 24,
-              "offset": 1424
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 5,
-                      "offset": 1429
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 9,
-                      "offset": 1433
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "div>",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 9,
-                      "offset": 1433
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 13,
-                      "offset": 1437
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 13,
-                      "offset": 1437
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 17,
-                      "offset": 1441
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "/div>",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 17,
-                      "offset": 1441
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 22,
-                      "offset": 1446
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 79,
-                  "column": 5,
-                  "offset": 1429
-                },
-                "end": {
-                  "line": 79,
-                  "column": 22,
-                  "offset": 1446
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 79,
-              "column": 1,
-              "offset": 1425
-            },
-            "end": {
-              "line": 79,
-              "column": 22,
-              "offset": 1446
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 5,
-                      "offset": 1451
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 9,
-                      "offset": 1455
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "http",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 9,
-                      "offset": 1455
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 13,
-                      "offset": 1459
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 13,
-                      "offset": 1459
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 20,
-                      "offset": 1466
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "google.com>",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 20,
-                      "offset": 1466
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 31,
                       "offset": 1477
                     },
                     "indent": []
                   }
+                },
+                {
+                  "type": "text",
+                  "value": "http",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 7,
+                      "offset": 1477
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 11,
+                      "offset": 1481
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 11,
+                      "offset": 1481
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 13,
+                      "offset": 1483
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "google.com>",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 13,
+                      "offset": 1483
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 24,
+                      "offset": 1494
+                    },
+                    "indent": []
+                  }
                 }
               ],
               "position": {
                 "start": {
                   "line": 80,
                   "column": 5,
-                  "offset": 1451
+                  "offset": 1475
                 },
                 "end": {
                   "line": 80,
-                  "column": 31,
-                  "offset": 1477
+                  "column": 24,
+                  "offset": 1494
                 },
                 "indent": []
               }
@@ -3529,12 +3386,224 @@
             "start": {
               "line": 80,
               "column": 1,
-              "offset": 1447
+              "offset": 1471
             },
             "end": {
               "line": 80,
+              "column": 24,
+              "offset": 1494
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 5,
+                      "offset": 1499
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 9,
+                      "offset": 1503
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "div>",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 9,
+                      "offset": 1503
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 13,
+                      "offset": 1507
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 13,
+                      "offset": 1507
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 17,
+                      "offset": 1511
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "/div>",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 17,
+                      "offset": 1511
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 22,
+                      "offset": 1516
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 81,
+                  "column": 5,
+                  "offset": 1499
+                },
+                "end": {
+                  "line": 81,
+                  "column": 22,
+                  "offset": 1516
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 81,
+              "column": 1,
+              "offset": 1495
+            },
+            "end": {
+              "line": 81,
+              "column": 22,
+              "offset": 1516
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 5,
+                      "offset": 1521
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 9,
+                      "offset": 1525
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "http",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 9,
+                      "offset": 1525
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 13,
+                      "offset": 1529
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 13,
+                      "offset": 1529
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 20,
+                      "offset": 1536
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "google.com>",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 20,
+                      "offset": 1536
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 31,
+                      "offset": 1547
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 82,
+                  "column": 5,
+                  "offset": 1521
+                },
+                "end": {
+                  "line": 82,
+                  "column": 31,
+                  "offset": 1547
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 82,
+              "column": 1,
+              "offset": 1517
+            },
+            "end": {
+              "line": 82,
               "column": 31,
-              "offset": 1477
+              "offset": 1547
             },
             "indent": []
           }
@@ -3542,14 +3611,14 @@
       ],
       "position": {
         "start": {
-          "line": 77,
+          "line": 79,
           "column": 1,
-          "offset": 1383
+          "offset": 1453
         },
         "end": {
-          "line": 80,
+          "line": 82,
           "column": 31,
-          "offset": 1477
+          "offset": 1547
         },
         "indent": [
           1,
@@ -3566,9 +3635,9 @@
       "offset": 0
     },
     "end": {
-      "line": 81,
+      "line": 83,
       "column": 1,
-      "offset": 1478
+      "offset": 1548
     }
   }
 }

--- a/test/tree/stringify-escape.json
+++ b/test/tree/stringify-escape.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,115 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in_the_middle_of_a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +354,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +369,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +400,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 6,
-                      "offset": 194
+                      "offset": 264
                     },
                     "indent": []
                   }
@@ -348,14 +417,14 @@
                   "value": "©",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 6,
-                      "offset": 194
+                      "offset": 264
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 11,
-                      "offset": 199
+                      "offset": 269
                     },
                     "indent": []
                   }
@@ -365,14 +434,14 @@
                   "value": "cat \\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 11,
-                      "offset": 199
+                      "offset": 269
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 16,
-                      "offset": 204
+                      "offset": 274
                     },
                     "indent": []
                   }
@@ -382,14 +451,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 16,
-                      "offset": 204
+                      "offset": 274
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 21,
-                      "offset": 209
+                      "offset": 279
                     },
                     "indent": []
                   }
@@ -399,14 +468,14 @@
                   "value": " \\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 21,
-                      "offset": 209
+                      "offset": 279
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "indent": []
                   }
@@ -416,14 +485,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +515,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +540,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "indent": []
                   }
@@ -488,14 +557,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "indent": []
                   }
@@ -505,14 +574,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "indent": []
                   }
@@ -522,14 +591,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "indent": []
                   }
@@ -539,14 +608,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "indent": []
                   }
@@ -556,14 +625,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 37,
-                      "offset": 253
+                      "offset": 323
                     },
                     "indent": []
                   }
@@ -571,14 +640,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 37,
-                  "offset": 253
+                  "offset": 323
                 },
                 "indent": []
               }
@@ -586,14 +655,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 37,
-              "offset": 253
+              "offset": 323
             },
             "indent": []
           }
@@ -611,14 +680,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 5,
-                      "offset": 258
+                      "offset": 328
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "indent": []
                   }
@@ -628,14 +697,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "indent": []
                   }
@@ -645,14 +714,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 43,
-                      "offset": 296
+                      "offset": 366
                     },
                     "indent": []
                   }
@@ -660,14 +729,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 13,
+                  "line": 15,
                   "column": 5,
-                  "offset": 258
+                  "offset": 328
                 },
                 "end": {
-                  "line": 13,
+                  "line": 15,
                   "column": 43,
-                  "offset": 296
+                  "offset": 366
                 },
                 "indent": []
               }
@@ -675,14 +744,14 @@
           ],
           "position": {
             "start": {
-              "line": 13,
+              "line": 15,
               "column": 1,
-              "offset": 254
+              "offset": 324
             },
             "end": {
-              "line": 13,
+              "line": 15,
               "column": 43,
-              "offset": 296
+              "offset": 366
             },
             "indent": []
           }
@@ -690,14 +759,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 13,
+          "line": 15,
           "column": 43,
-          "offset": 296
+          "offset": 366
         },
         "indent": [
           1,
@@ -713,14 +782,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 15,
+              "line": 17,
               "column": 1,
-              "offset": 298
+              "offset": 368
             },
             "end": {
-              "line": 15,
+              "line": 17,
               "column": 63,
-              "offset": 360
+              "offset": 430
             },
             "indent": []
           }
@@ -728,14 +797,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 17,
           "column": 1,
-          "offset": 298
+          "offset": 368
         },
         "end": {
-          "line": 15,
+          "line": 17,
           "column": 63,
-          "offset": 360
+          "offset": 430
         },
         "indent": []
       }
@@ -753,14 +822,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 17,
+                  "line": 19,
                   "column": 2,
-                  "offset": 363
+                  "offset": 433
                 },
                 "end": {
-                  "line": 17,
+                  "line": 19,
                   "column": 5,
-                  "offset": 366
+                  "offset": 436
                 },
                 "indent": []
               }
@@ -768,14 +837,14 @@
           ],
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 1,
-              "offset": 362
+              "offset": 432
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "indent": []
           }
@@ -785,14 +854,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "indent": []
           }
@@ -802,14 +871,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 13,
-              "offset": 374
+              "offset": 444
             },
             "indent": []
           }
@@ -817,14 +886,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 19,
           "column": 1,
-          "offset": 362
+          "offset": 432
         },
         "end": {
-          "line": 17,
+          "line": 19,
           "column": 13,
-          "offset": 374
+          "offset": 444
         },
         "indent": []
       }
@@ -837,14 +906,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 19,
+              "line": 21,
               "column": 1,
-              "offset": 376
+              "offset": 446
             },
             "end": {
-              "line": 19,
+              "line": 21,
               "column": 53,
-              "offset": 428
+              "offset": 498
             },
             "indent": []
           }
@@ -852,14 +921,14 @@
       ],
       "position": {
         "start": {
-          "line": 19,
+          "line": 21,
           "column": 1,
-          "offset": 376
+          "offset": 446
         },
         "end": {
-          "line": 19,
+          "line": 21,
           "column": 53,
-          "offset": 428
+          "offset": 498
         },
         "indent": []
       }
@@ -872,14 +941,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 430
+              "offset": 500
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "indent": []
           }
@@ -889,14 +958,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "indent": [
               1
@@ -908,14 +977,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -925,14 +994,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "indent": [
               1
@@ -944,14 +1013,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "indent": []
           }
@@ -961,14 +1030,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 21,
-              "offset": 488
+              "offset": 558
             },
             "indent": []
           }
@@ -976,14 +1045,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 23,
           "column": 1,
-          "offset": 430
+          "offset": 500
         },
         "end": {
-          "line": 23,
+          "line": 25,
           "column": 21,
-          "offset": 488
+          "offset": 558
         },
         "indent": [
           1,
@@ -999,14 +1068,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 1,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 25,
+              "line": 27,
               "column": 25,
-              "offset": 514
+              "offset": 584
             },
             "indent": []
           }
@@ -1014,14 +1083,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 27,
           "column": 1,
-          "offset": 490
+          "offset": 560
         },
         "end": {
-          "line": 25,
+          "line": 27,
           "column": 25,
-          "offset": 514
+          "offset": 584
         },
         "indent": []
       }
@@ -1034,14 +1103,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 1,
-              "offset": 516
+              "offset": 586
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "indent": []
           }
@@ -1051,14 +1120,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 21,
-              "offset": 536
+              "offset": 606
             },
             "indent": []
           }
@@ -1066,14 +1135,14 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 29,
           "column": 1,
-          "offset": 516
+          "offset": 586
         },
         "end": {
-          "line": 27,
+          "line": 29,
           "column": 21,
-          "offset": 536
+          "offset": 606
         },
         "indent": []
       }
@@ -1086,14 +1155,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 29,
+              "line": 31,
               "column": 1,
-              "offset": 538
+              "offset": 608
             },
             "end": {
-              "line": 29,
+              "line": 31,
               "column": 16,
-              "offset": 553
+              "offset": 623
             },
             "indent": []
           }
@@ -1101,14 +1170,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 31,
           "column": 1,
-          "offset": 538
+          "offset": 608
         },
         "end": {
-          "line": 29,
+          "line": 31,
           "column": 16,
-          "offset": 553
+          "offset": 623
         },
         "indent": []
       }
@@ -1121,14 +1190,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 1,
-              "offset": 555
+              "offset": 625
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1138,14 +1207,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "indent": [
               1
@@ -1157,14 +1226,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "indent": []
           }
@@ -1174,14 +1243,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 23,
-              "offset": 594
+              "offset": 664
             },
             "indent": []
           }
@@ -1189,14 +1258,14 @@
       ],
       "position": {
         "start": {
-          "line": 31,
+          "line": 33,
           "column": 1,
-          "offset": 555
+          "offset": 625
         },
         "end": {
-          "line": 32,
+          "line": 34,
           "column": 23,
-          "offset": 594
+          "offset": 664
         },
         "indent": [
           1
@@ -1211,14 +1280,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 1,
-              "offset": 596
+              "offset": 666
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 62,
-              "offset": 657
+              "offset": 727
             },
             "indent": []
           }
@@ -1226,14 +1295,14 @@
       ],
       "position": {
         "start": {
-          "line": 34,
+          "line": 36,
           "column": 1,
-          "offset": 596
+          "offset": 666
         },
         "end": {
-          "line": 34,
+          "line": 36,
           "column": 62,
-          "offset": 657
+          "offset": 727
         },
         "indent": []
       }
@@ -1262,14 +1331,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 664
+                          "offset": 734
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 15,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1277,14 +1346,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 663
+                      "offset": 733
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 16,
-                      "offset": 674
+                      "offset": 744
                     },
                     "indent": []
                   }
@@ -1292,14 +1361,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 663
+                  "offset": 733
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 16,
-                  "offset": 674
+                  "offset": 744
                 },
                 "indent": []
               }
@@ -1307,14 +1376,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 659
+              "offset": 729
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 16,
-              "offset": 674
+              "offset": 744
             },
             "indent": []
           }
@@ -1337,14 +1406,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1354,14 +1423,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "indent": []
                       }
@@ -1371,14 +1440,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 16,
-                          "offset": 690
+                          "offset": 760
                         },
                         "indent": []
                       }
@@ -1386,14 +1455,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 679
+                      "offset": 749
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 17,
-                      "offset": 691
+                      "offset": 761
                     },
                     "indent": []
                   }
@@ -1401,14 +1470,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 679
+                  "offset": 749
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 17,
-                  "offset": 691
+                  "offset": 761
                 },
                 "indent": []
               }
@@ -1416,14 +1485,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 675
+              "offset": 745
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 17,
-              "offset": 691
+              "offset": 761
             },
             "indent": []
           }
@@ -1446,14 +1515,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 697
+                          "offset": 767
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 700
+                          "offset": 770
                         },
                         "indent": []
                       }
@@ -1461,14 +1530,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 696
+                      "offset": 766
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 10,
-                      "offset": 701
+                      "offset": 771
                     },
                     "indent": []
                   }
@@ -1476,14 +1545,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 696
+                  "offset": 766
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 10,
-                  "offset": 701
+                  "offset": 771
                 },
                 "indent": []
               }
@@ -1491,14 +1560,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 692
+              "offset": 762
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 10,
-              "offset": 701
+              "offset": 771
             },
             "indent": []
           }
@@ -1521,14 +1590,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1538,14 +1607,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1555,14 +1624,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 10,
-                          "offset": 711
+                          "offset": 781
                         },
                         "indent": []
                       }
@@ -1570,14 +1639,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 706
+                      "offset": 776
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 11,
-                      "offset": 712
+                      "offset": 782
                     },
                     "indent": []
                   }
@@ -1585,14 +1654,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 706
+                  "offset": 776
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 11,
-                  "offset": 712
+                  "offset": 782
                 },
                 "indent": []
               }
@@ -1600,14 +1669,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 11,
-              "offset": 712
+              "offset": 782
             },
             "indent": []
           }
@@ -1630,14 +1699,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 718
+                          "offset": 788
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "indent": []
                       }
@@ -1647,14 +1716,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "indent": []
                       }
@@ -1664,14 +1733,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 723
+                          "offset": 793
                         },
                         "indent": []
                       }
@@ -1679,14 +1748,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 717
+                      "offset": 787
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 12,
-                      "offset": 724
+                      "offset": 794
                     },
                     "indent": []
                   }
@@ -1694,14 +1763,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 717
+                  "offset": 787
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 12,
-                  "offset": 724
+                  "offset": 794
                 },
                 "indent": []
               }
@@ -1709,14 +1778,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 713
+              "offset": 783
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 12,
-              "offset": 724
+              "offset": 794
             },
             "indent": []
           }
@@ -1739,14 +1808,14 @@
                       "value": "a_a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 6,
-                          "offset": 730
+                          "offset": 800
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 9,
-                          "offset": 733
+                          "offset": 803
                         },
                         "indent": []
                       }
@@ -1756,14 +1825,14 @@
                       "value": "_",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 9,
-                          "offset": 733
+                          "offset": 803
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "indent": []
                       }
@@ -1773,14 +1842,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 12,
-                          "offset": 736
+                          "offset": 806
                         },
                         "indent": []
                       }
@@ -1788,14 +1857,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 41,
+                      "line": 43,
                       "column": 5,
-                      "offset": 729
+                      "offset": 799
                     },
                     "end": {
-                      "line": 41,
+                      "line": 43,
                       "column": 13,
-                      "offset": 737
+                      "offset": 807
                     },
                     "indent": []
                   }
@@ -1803,14 +1872,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
+                  "line": 43,
                   "column": 5,
-                  "offset": 729
+                  "offset": 799
                 },
                 "end": {
-                  "line": 41,
+                  "line": 43,
                   "column": 13,
-                  "offset": 737
+                  "offset": 807
                 },
                 "indent": []
               }
@@ -1818,14 +1887,14 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 43,
               "column": 1,
-              "offset": 725
+              "offset": 795
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 13,
-              "offset": 737
+              "offset": 807
             },
             "indent": []
           }
@@ -1833,14 +1902,14 @@
       ],
       "position": {
         "start": {
-          "line": 36,
+          "line": 38,
           "column": 1,
-          "offset": 659
+          "offset": 729
         },
         "end": {
-          "line": 41,
+          "line": 43,
           "column": 13,
-          "offset": 737
+          "offset": 807
         },
         "indent": [
           1,
@@ -1862,14 +1931,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 43,
+                  "line": 45,
                   "column": 3,
-                  "offset": 741
+                  "offset": 811
                 },
                 "end": {
-                  "line": 43,
+                  "line": 45,
                   "column": 7,
-                  "offset": 745
+                  "offset": 815
                 },
                 "indent": []
               }
@@ -1877,14 +1946,14 @@
           ],
           "position": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 1,
-              "offset": 739
+              "offset": 809
             },
             "end": {
-              "line": 43,
+              "line": 45,
               "column": 9,
-              "offset": 747
+              "offset": 817
             },
             "indent": []
           }
@@ -1892,14 +1961,14 @@
       ],
       "position": {
         "start": {
-          "line": 43,
+          "line": 45,
           "column": 1,
-          "offset": 739
+          "offset": 809
         },
         "end": {
-          "line": 43,
+          "line": 45,
           "column": 9,
-          "offset": 747
+          "offset": 817
         },
         "indent": []
       }
@@ -1912,14 +1981,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 45,
+              "line": 47,
               "column": 1,
-              "offset": 749
+              "offset": 819
             },
             "end": {
-              "line": 45,
+              "line": 47,
               "column": 33,
-              "offset": 781
+              "offset": 851
             },
             "indent": []
           }
@@ -1927,14 +1996,14 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 47,
           "column": 1,
-          "offset": 749
+          "offset": 819
         },
         "end": {
-          "line": 45,
+          "line": 47,
           "column": 33,
-          "offset": 781
+          "offset": 851
         },
         "indent": []
       }
@@ -1958,14 +2027,14 @@
                   "value": "http\\://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 787
+                      "offset": 857
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 842
+                      "offset": 912
                     },
                     "indent": []
                   }
@@ -1973,14 +2042,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 787
+                  "offset": 857
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 842
+                  "offset": 912
                 },
                 "indent": []
               }
@@ -1988,14 +2057,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 783
+              "offset": 853
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 842
+              "offset": 912
             },
             "indent": []
           }
@@ -2013,14 +2082,14 @@
                   "value": "https\\://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 5,
-                      "offset": 847
+                      "offset": 917
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 61,
-                      "offset": 903
+                      "offset": 973
                     },
                     "indent": []
                   }
@@ -2028,14 +2097,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 48,
+                  "line": 50,
                   "column": 5,
-                  "offset": 847
+                  "offset": 917
                 },
                 "end": {
-                  "line": 48,
+                  "line": 50,
                   "column": 61,
-                  "offset": 903
+                  "offset": 973
                 },
                 "indent": []
               }
@@ -2043,14 +2112,14 @@
           ],
           "position": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 1,
-              "offset": 843
+              "offset": 913
             },
             "end": {
-              "line": 48,
+              "line": 50,
               "column": 61,
-              "offset": 903
+              "offset": 973
             },
             "indent": []
           }
@@ -2068,14 +2137,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 5,
-                      "offset": 908
+                      "offset": 978
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "indent": []
                   }
@@ -2085,14 +2154,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "indent": []
                   }
@@ -2102,14 +2171,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 65,
-                      "offset": 968
+                      "offset": 1038
                     },
                     "indent": []
                   }
@@ -2117,14 +2186,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 51,
                   "column": 5,
-                  "offset": 908
+                  "offset": 978
                 },
                 "end": {
-                  "line": 49,
+                  "line": 51,
                   "column": 65,
-                  "offset": 968
+                  "offset": 1038
                 },
                 "indent": []
               }
@@ -2132,14 +2201,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 904
+              "offset": 974
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 65,
-              "offset": 968
+              "offset": 1038
             },
             "indent": []
           }
@@ -2157,14 +2226,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 5,
-                      "offset": 973
+                      "offset": 1043
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "indent": []
                   }
@@ -2174,14 +2243,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "indent": []
                   }
@@ -2191,14 +2260,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 66,
-                      "offset": 1034
+                      "offset": 1104
                     },
                     "indent": []
                   }
@@ -2206,14 +2275,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 50,
+                  "line": 52,
                   "column": 5,
-                  "offset": 973
+                  "offset": 1043
                 },
                 "end": {
-                  "line": 50,
+                  "line": 52,
                   "column": 66,
-                  "offset": 1034
+                  "offset": 1104
                 },
                 "indent": []
               }
@@ -2221,14 +2290,14 @@
           ],
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 1,
-              "offset": 969
+              "offset": 1039
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 66,
-              "offset": 1034
+              "offset": 1104
             },
             "indent": []
           }
@@ -2236,14 +2305,14 @@
       ],
       "position": {
         "start": {
-          "line": 47,
+          "line": 49,
           "column": 1,
-          "offset": 783
+          "offset": 853
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 66,
-          "offset": 1034
+          "offset": 1104
         },
         "indent": [
           1,
@@ -2260,14 +2329,14 @@
           "value": "Double tildes should be ",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 1036
+              "offset": 1106
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "indent": []
           }
@@ -2277,14 +2346,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "indent": []
           }
@@ -2294,14 +2363,14 @@
           "value": "~escaped",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "indent": []
           }
@@ -2311,14 +2380,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "indent": []
           }
@@ -2328,14 +2397,14 @@
           "value": "~.\nAnd here: foo~~.",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "end": {
-              "line": 53,
+              "line": 55,
               "column": 17,
-              "offset": 1091
+              "offset": 1161
             },
             "indent": [
               1
@@ -2345,14 +2414,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 1036
+          "offset": 1106
         },
         "end": {
-          "line": 53,
+          "line": 55,
           "column": 17,
-          "offset": 1091
+          "offset": 1161
         },
         "indent": [
           1
@@ -2367,14 +2436,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 55,
+              "line": 57,
               "column": 1,
-              "offset": 1093
+              "offset": 1163
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 36,
-              "offset": 1128
+              "offset": 1198
             },
             "indent": []
           }
@@ -2382,14 +2451,14 @@
       ],
       "position": {
         "start": {
-          "line": 55,
+          "line": 57,
           "column": 1,
-          "offset": 1093
+          "offset": 1163
         },
         "end": {
-          "line": 55,
+          "line": 57,
           "column": 36,
-          "offset": 1128
+          "offset": 1198
         },
         "indent": []
       }
@@ -2412,14 +2481,14 @@
                   "value": "here",
                   "position": {
                     "start": {
-                      "line": 57,
+                      "line": 59,
                       "column": 3,
-                      "offset": 1132
+                      "offset": 1202
                     },
                     "end": {
-                      "line": 57,
+                      "line": 59,
                       "column": 7,
-                      "offset": 1136
+                      "offset": 1206
                     },
                     "indent": []
                   }
@@ -2427,14 +2496,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 57,
+                  "line": 59,
                   "column": 3,
-                  "offset": 1132
+                  "offset": 1202
                 },
                 "end": {
-                  "line": 57,
+                  "line": 59,
                   "column": 9,
-                  "offset": 1138
+                  "offset": 1208
                 },
                 "indent": []
               }
@@ -2447,14 +2516,14 @@
                   "value": "they",
                   "position": {
                     "start": {
-                      "line": 57,
+                      "line": 59,
                       "column": 12,
-                      "offset": 1141
+                      "offset": 1211
                     },
                     "end": {
-                      "line": 57,
+                      "line": 59,
                       "column": 16,
-                      "offset": 1145
+                      "offset": 1215
                     },
                     "indent": []
                   }
@@ -2462,14 +2531,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 57,
+                  "line": 59,
                   "column": 12,
-                  "offset": 1141
+                  "offset": 1211
                 },
                 "end": {
-                  "line": 57,
+                  "line": 59,
                   "column": 20,
-                  "offset": 1149
+                  "offset": 1219
                 },
                 "indent": []
               }
@@ -2477,14 +2546,14 @@
           ],
           "position": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 57,
+              "line": 59,
               "column": 22,
-              "offset": 1151
+              "offset": 1221
             },
             "indent": []
           }
@@ -2500,14 +2569,14 @@
                   "value": "should",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 3,
-                      "offset": 1176
+                      "offset": 1246
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 9,
-                      "offset": 1182
+                      "offset": 1252
                     },
                     "indent": []
                   }
@@ -2515,14 +2584,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 59,
+                  "line": 61,
                   "column": 3,
-                  "offset": 1176
+                  "offset": 1246
                 },
                 "end": {
-                  "line": 59,
+                  "line": 61,
                   "column": 9,
-                  "offset": 1182
+                  "offset": 1252
                 },
                 "indent": []
               }
@@ -2535,14 +2604,14 @@
                   "value": "tho",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 12,
-                      "offset": 1185
+                      "offset": 1255
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 15,
-                      "offset": 1188
+                      "offset": 1258
                     },
                     "indent": []
                   }
@@ -2552,14 +2621,14 @@
                   "value": "|",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 15,
-                      "offset": 1188
+                      "offset": 1258
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 17,
-                      "offset": 1190
+                      "offset": 1260
                     },
                     "indent": []
                   }
@@ -2569,14 +2638,14 @@
                   "value": "ugh",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 17,
-                      "offset": 1190
+                      "offset": 1260
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 20,
-                      "offset": 1193
+                      "offset": 1263
                     },
                     "indent": []
                   }
@@ -2584,14 +2653,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 59,
+                  "line": 61,
                   "column": 12,
-                  "offset": 1185
+                  "offset": 1255
                 },
                 "end": {
-                  "line": 59,
+                  "line": 61,
                   "column": 20,
-                  "offset": 1193
+                  "offset": 1263
                 },
                 "indent": []
               }
@@ -2599,14 +2668,14 @@
           ],
           "position": {
             "start": {
-              "line": 59,
+              "line": 61,
               "column": 1,
-              "offset": 1174
+              "offset": 1244
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 22,
-              "offset": 1195
+              "offset": 1265
             },
             "indent": []
           }
@@ -2614,14 +2683,14 @@
       ],
       "position": {
         "start": {
-          "line": 57,
+          "line": 59,
           "column": 1,
-          "offset": 1130
+          "offset": 1200
         },
         "end": {
-          "line": 59,
+          "line": 61,
           "column": 22,
-          "offset": 1195
+          "offset": 1265
         },
         "indent": [
           1,
@@ -2637,14 +2706,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1197
+              "offset": 1267
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 10,
-              "offset": 1206
+              "offset": 1276
             },
             "indent": []
           }
@@ -2652,14 +2721,14 @@
       ],
       "position": {
         "start": {
-          "line": 61,
+          "line": 63,
           "column": 1,
-          "offset": 1197
+          "offset": 1267
         },
         "end": {
-          "line": 61,
+          "line": 63,
           "column": 10,
-          "offset": 1206
+          "offset": 1276
         },
         "indent": []
       }
@@ -2672,14 +2741,14 @@
           "value": "| here   | they   |\n",
           "position": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 1,
-              "offset": 1208
+              "offset": 1278
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "indent": [
               1
@@ -2691,14 +2760,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "indent": []
           }
@@ -2708,14 +2777,14 @@
           "value": " ---- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "indent": []
           }
@@ -2725,14 +2794,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "indent": []
           }
@@ -2742,14 +2811,14 @@
           "value": " ----- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "indent": []
           }
@@ -2759,14 +2828,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "indent": []
           }
@@ -2776,14 +2845,14 @@
           "value": "\n| should | though |",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "end": {
-              "line": 65,
+              "line": 67,
               "column": 20,
-              "offset": 1267
+              "offset": 1337
             },
             "indent": [
               1
@@ -2793,14 +2862,14 @@
       ],
       "position": {
         "start": {
-          "line": 63,
+          "line": 65,
           "column": 1,
-          "offset": 1208
+          "offset": 1278
         },
         "end": {
-          "line": 65,
+          "line": 67,
           "column": 20,
-          "offset": 1267
+          "offset": 1337
         },
         "indent": [
           1,
@@ -2816,14 +2885,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1269
+              "offset": 1339
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 10,
-              "offset": 1278
+              "offset": 1348
             },
             "indent": []
           }
@@ -2831,14 +2900,14 @@
       ],
       "position": {
         "start": {
-          "line": 67,
+          "line": 69,
           "column": 1,
-          "offset": 1269
+          "offset": 1339
         },
         "end": {
-          "line": 67,
+          "line": 69,
           "column": 10,
-          "offset": 1278
+          "offset": 1348
         },
         "indent": []
       }
@@ -2851,14 +2920,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 69,
+              "line": 71,
               "column": 1,
-              "offset": 1280
+              "offset": 1350
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "indent": [
               1
@@ -2870,14 +2939,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "indent": []
           }
@@ -2887,14 +2956,14 @@
           "value": "--- ",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "indent": []
           }
@@ -2904,14 +2973,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "indent": []
           }
@@ -2921,14 +2990,14 @@
           "value": " ------\nshould | though",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "end": {
-              "line": 71,
+              "line": 73,
               "column": 16,
-              "offset": 1325
+              "offset": 1395
             },
             "indent": [
               1
@@ -2938,14 +3007,14 @@
       ],
       "position": {
         "start": {
-          "line": 69,
+          "line": 71,
           "column": 1,
-          "offset": 1280
+          "offset": 1350
         },
         "end": {
-          "line": 71,
+          "line": 73,
           "column": 16,
-          "offset": 1325
+          "offset": 1395
         },
         "indent": [
           1,
@@ -2964,14 +3033,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 73,
+                  "line": 75,
                   "column": 3,
-                  "offset": 1329
+                  "offset": 1399
                 },
                 "end": {
-                  "line": 73,
+                  "line": 75,
                   "column": 14,
-                  "offset": 1340
+                  "offset": 1410
                 },
                 "indent": []
               }
@@ -2979,14 +3048,14 @@
           ],
           "position": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 1,
-              "offset": 1327
+              "offset": 1397
             },
             "end": {
-              "line": 73,
+              "line": 75,
               "column": 16,
-              "offset": 1342
+              "offset": 1412
             },
             "indent": []
           }
@@ -2994,14 +3063,14 @@
       ],
       "position": {
         "start": {
-          "line": 73,
+          "line": 75,
           "column": 1,
-          "offset": 1327
+          "offset": 1397
         },
         "end": {
-          "line": 73,
+          "line": 75,
           "column": 16,
-          "offset": 1342
+          "offset": 1412
         },
         "indent": []
       }
@@ -3014,14 +3083,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1344
+              "offset": 1414
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 38,
-              "offset": 1381
+              "offset": 1451
             },
             "indent": []
           }
@@ -3029,14 +3098,14 @@
       ],
       "position": {
         "start": {
-          "line": 75,
+          "line": 77,
           "column": 1,
-          "offset": 1344
+          "offset": 1414
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 38,
-          "offset": 1381
+          "offset": 1451
         },
         "indent": []
       }
@@ -3060,14 +3129,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 5,
-                      "offset": 1387
+                      "offset": 1457
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 6,
-                      "offset": 1388
+                      "offset": 1458
                     },
                     "indent": []
                   }
@@ -3077,14 +3146,14 @@
                   "value": "<div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 6,
-                      "offset": 1388
+                      "offset": 1458
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "indent": []
                   }
@@ -3094,14 +3163,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 12,
-                      "offset": 1394
+                      "offset": 1464
                     },
                     "indent": []
                   }
@@ -3111,14 +3180,14 @@
                   "value": "</div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 12,
-                      "offset": 1394
+                      "offset": 1464
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 18,
-                      "offset": 1400
+                      "offset": 1470
                     },
                     "indent": []
                   }
@@ -3126,14 +3195,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 77,
+                  "line": 79,
                   "column": 5,
-                  "offset": 1387
+                  "offset": 1457
                 },
                 "end": {
-                  "line": 77,
+                  "line": 79,
                   "column": 18,
-                  "offset": 1400
+                  "offset": 1470
                 },
                 "indent": []
               }
@@ -3141,14 +3210,14 @@
           ],
           "position": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 1,
-              "offset": 1383
+              "offset": 1453
             },
             "end": {
-              "line": 77,
+              "line": 79,
               "column": 18,
-              "offset": 1400
+              "offset": 1470
             },
             "indent": []
           }
@@ -3166,14 +3235,14 @@
                   "value": "\\<http\\:google.com>",
                   "position": {
                     "start": {
-                      "line": 78,
+                      "line": 80,
                       "column": 5,
-                      "offset": 1405
+                      "offset": 1475
                     },
                     "end": {
-                      "line": 78,
+                      "line": 80,
                       "column": 24,
-                      "offset": 1424
+                      "offset": 1494
                     },
                     "indent": []
                   }
@@ -3181,14 +3250,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 78,
+                  "line": 80,
                   "column": 5,
-                  "offset": 1405
+                  "offset": 1475
                 },
                 "end": {
-                  "line": 78,
+                  "line": 80,
                   "column": 24,
-                  "offset": 1424
+                  "offset": 1494
                 },
                 "indent": []
               }
@@ -3196,14 +3265,14 @@
           ],
           "position": {
             "start": {
-              "line": 78,
+              "line": 80,
               "column": 1,
-              "offset": 1401
+              "offset": 1471
             },
             "end": {
-              "line": 78,
+              "line": 80,
               "column": 24,
-              "offset": 1424
+              "offset": 1494
             },
             "indent": []
           }
@@ -3221,14 +3290,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 5,
-                      "offset": 1429
+                      "offset": 1499
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 9,
-                      "offset": 1433
+                      "offset": 1503
                     },
                     "indent": []
                   }
@@ -3238,14 +3307,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 9,
-                      "offset": 1433
+                      "offset": 1503
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 13,
-                      "offset": 1437
+                      "offset": 1507
                     },
                     "indent": []
                   }
@@ -3255,14 +3324,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 13,
-                      "offset": 1437
+                      "offset": 1507
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 17,
-                      "offset": 1441
+                      "offset": 1511
                     },
                     "indent": []
                   }
@@ -3272,14 +3341,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 17,
-                      "offset": 1441
+                      "offset": 1511
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 22,
-                      "offset": 1446
+                      "offset": 1516
                     },
                     "indent": []
                   }
@@ -3287,14 +3356,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 79,
+                  "line": 81,
                   "column": 5,
-                  "offset": 1429
+                  "offset": 1499
                 },
                 "end": {
-                  "line": 79,
+                  "line": 81,
                   "column": 22,
-                  "offset": 1446
+                  "offset": 1516
                 },
                 "indent": []
               }
@@ -3302,14 +3371,14 @@
           ],
           "position": {
             "start": {
-              "line": 79,
+              "line": 81,
               "column": 1,
-              "offset": 1425
+              "offset": 1495
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 22,
-              "offset": 1446
+              "offset": 1516
             },
             "indent": []
           }
@@ -3327,14 +3396,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 5,
-                      "offset": 1451
+                      "offset": 1521
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 9,
-                      "offset": 1455
+                      "offset": 1525
                     },
                     "indent": []
                   }
@@ -3344,14 +3413,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 9,
-                      "offset": 1455
+                      "offset": 1525
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 13,
-                      "offset": 1459
+                      "offset": 1529
                     },
                     "indent": []
                   }
@@ -3361,14 +3430,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 13,
-                      "offset": 1459
+                      "offset": 1529
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 20,
-                      "offset": 1466
+                      "offset": 1536
                     },
                     "indent": []
                   }
@@ -3378,14 +3447,14 @@
                   "value": "google.com>",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 20,
-                      "offset": 1466
+                      "offset": 1536
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 31,
-                      "offset": 1477
+                      "offset": 1547
                     },
                     "indent": []
                   }
@@ -3393,14 +3462,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 80,
+                  "line": 82,
                   "column": 5,
-                  "offset": 1451
+                  "offset": 1521
                 },
                 "end": {
-                  "line": 80,
+                  "line": 82,
                   "column": 31,
-                  "offset": 1477
+                  "offset": 1547
                 },
                 "indent": []
               }
@@ -3408,14 +3477,14 @@
           ],
           "position": {
             "start": {
-              "line": 80,
+              "line": 82,
               "column": 1,
-              "offset": 1447
+              "offset": 1517
             },
             "end": {
-              "line": 80,
+              "line": 82,
               "column": 31,
-              "offset": 1477
+              "offset": 1547
             },
             "indent": []
           }
@@ -3423,14 +3492,14 @@
       ],
       "position": {
         "start": {
-          "line": 77,
+          "line": 79,
           "column": 1,
-          "offset": 1383
+          "offset": 1453
         },
         "end": {
-          "line": 80,
+          "line": 82,
           "column": 31,
-          "offset": 1477
+          "offset": 1547
         },
         "indent": [
           1,
@@ -3447,9 +3516,9 @@
       "offset": 0
     },
     "end": {
-      "line": 81,
+      "line": 83,
       "column": 1,
-      "offset": 1478
+      "offset": 1548
     }
   }
 }

--- a/test/tree/stringify-escape.nogfm.commonmark.json
+++ b/test/tree/stringify-escape.nogfm.commonmark.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,115 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in_the_middle_of_a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +354,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +369,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +400,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "indent": []
                   }
@@ -348,14 +417,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "indent": []
                   }
@@ -365,14 +434,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "indent": []
                   }
@@ -382,14 +451,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "indent": []
                   }
@@ -399,14 +468,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "indent": []
                   }
@@ -416,14 +485,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +515,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +540,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "indent": []
                   }
@@ -488,14 +557,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "indent": []
                   }
@@ -505,14 +574,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "indent": []
                   }
@@ -522,14 +591,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "indent": []
                   }
@@ -539,14 +608,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "indent": []
                   }
@@ -556,14 +625,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 37,
-                      "offset": 253
+                      "offset": 323
                     },
                     "indent": []
                   }
@@ -571,14 +640,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 37,
-                  "offset": 253
+                  "offset": 323
                 },
                 "indent": []
               }
@@ -586,14 +655,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 37,
-              "offset": 253
+              "offset": 323
             },
             "indent": []
           }
@@ -611,14 +680,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 5,
-                      "offset": 258
+                      "offset": 328
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "indent": []
                   }
@@ -628,14 +697,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "indent": []
                   }
@@ -645,14 +714,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 43,
-                      "offset": 296
+                      "offset": 366
                     },
                     "indent": []
                   }
@@ -660,14 +729,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 13,
+                  "line": 15,
                   "column": 5,
-                  "offset": 258
+                  "offset": 328
                 },
                 "end": {
-                  "line": 13,
+                  "line": 15,
                   "column": 43,
-                  "offset": 296
+                  "offset": 366
                 },
                 "indent": []
               }
@@ -675,14 +744,14 @@
           ],
           "position": {
             "start": {
-              "line": 13,
+              "line": 15,
               "column": 1,
-              "offset": 254
+              "offset": 324
             },
             "end": {
-              "line": 13,
+              "line": 15,
               "column": 43,
-              "offset": 296
+              "offset": 366
             },
             "indent": []
           }
@@ -690,14 +759,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 13,
+          "line": 15,
           "column": 43,
-          "offset": 296
+          "offset": 366
         },
         "indent": [
           1,
@@ -713,14 +782,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 15,
+              "line": 17,
               "column": 1,
-              "offset": 298
+              "offset": 368
             },
             "end": {
-              "line": 15,
+              "line": 17,
               "column": 63,
-              "offset": 360
+              "offset": 430
             },
             "indent": []
           }
@@ -728,14 +797,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 17,
           "column": 1,
-          "offset": 298
+          "offset": 368
         },
         "end": {
-          "line": 15,
+          "line": 17,
           "column": 63,
-          "offset": 360
+          "offset": 430
         },
         "indent": []
       }
@@ -753,14 +822,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 17,
+                  "line": 19,
                   "column": 2,
-                  "offset": 363
+                  "offset": 433
                 },
                 "end": {
-                  "line": 17,
+                  "line": 19,
                   "column": 5,
-                  "offset": 366
+                  "offset": 436
                 },
                 "indent": []
               }
@@ -768,14 +837,14 @@
           ],
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 1,
-              "offset": 362
+              "offset": 432
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "indent": []
           }
@@ -785,14 +854,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "indent": []
           }
@@ -802,14 +871,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 13,
-              "offset": 374
+              "offset": 444
             },
             "indent": []
           }
@@ -817,14 +886,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 19,
           "column": 1,
-          "offset": 362
+          "offset": 432
         },
         "end": {
-          "line": 17,
+          "line": 19,
           "column": 13,
-          "offset": 374
+          "offset": 444
         },
         "indent": []
       }
@@ -837,14 +906,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 19,
+              "line": 21,
               "column": 1,
-              "offset": 376
+              "offset": 446
             },
             "end": {
-              "line": 19,
+              "line": 21,
               "column": 53,
-              "offset": 428
+              "offset": 498
             },
             "indent": []
           }
@@ -852,14 +921,14 @@
       ],
       "position": {
         "start": {
-          "line": 19,
+          "line": 21,
           "column": 1,
-          "offset": 376
+          "offset": 446
         },
         "end": {
-          "line": 19,
+          "line": 21,
           "column": 53,
-          "offset": 428
+          "offset": 498
         },
         "indent": []
       }
@@ -872,14 +941,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 430
+              "offset": 500
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "indent": []
           }
@@ -889,14 +958,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "indent": [
               1
@@ -908,14 +977,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -925,14 +994,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "indent": [
               1
@@ -944,14 +1013,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "indent": []
           }
@@ -961,14 +1030,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 21,
-              "offset": 488
+              "offset": 558
             },
             "indent": []
           }
@@ -976,14 +1045,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 23,
           "column": 1,
-          "offset": 430
+          "offset": 500
         },
         "end": {
-          "line": 23,
+          "line": 25,
           "column": 21,
-          "offset": 488
+          "offset": 558
         },
         "indent": [
           1,
@@ -999,14 +1068,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 1,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 25,
+              "line": 27,
               "column": 25,
-              "offset": 514
+              "offset": 584
             },
             "indent": []
           }
@@ -1014,14 +1083,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 27,
           "column": 1,
-          "offset": 490
+          "offset": 560
         },
         "end": {
-          "line": 25,
+          "line": 27,
           "column": 25,
-          "offset": 514
+          "offset": 584
         },
         "indent": []
       }
@@ -1034,14 +1103,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 1,
-              "offset": 516
+              "offset": 586
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "indent": []
           }
@@ -1051,14 +1120,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 21,
-              "offset": 536
+              "offset": 606
             },
             "indent": []
           }
@@ -1066,14 +1135,14 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 29,
           "column": 1,
-          "offset": 516
+          "offset": 586
         },
         "end": {
-          "line": 27,
+          "line": 29,
           "column": 21,
-          "offset": 536
+          "offset": 606
         },
         "indent": []
       }
@@ -1086,14 +1155,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 29,
+              "line": 31,
               "column": 1,
-              "offset": 538
+              "offset": 608
             },
             "end": {
-              "line": 29,
+              "line": 31,
               "column": 16,
-              "offset": 553
+              "offset": 623
             },
             "indent": []
           }
@@ -1101,14 +1170,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 31,
           "column": 1,
-          "offset": 538
+          "offset": 608
         },
         "end": {
-          "line": 29,
+          "line": 31,
           "column": 16,
-          "offset": 553
+          "offset": 623
         },
         "indent": []
       }
@@ -1121,14 +1190,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 1,
-              "offset": 555
+              "offset": 625
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1138,14 +1207,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "indent": [
               1
@@ -1157,14 +1226,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "indent": []
           }
@@ -1174,14 +1243,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 23,
-              "offset": 594
+              "offset": 664
             },
             "indent": []
           }
@@ -1189,14 +1258,14 @@
       ],
       "position": {
         "start": {
-          "line": 31,
+          "line": 33,
           "column": 1,
-          "offset": 555
+          "offset": 625
         },
         "end": {
-          "line": 32,
+          "line": 34,
           "column": 23,
-          "offset": 594
+          "offset": 664
         },
         "indent": [
           1
@@ -1211,14 +1280,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 1,
-              "offset": 596
+              "offset": 666
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 62,
-              "offset": 657
+              "offset": 727
             },
             "indent": []
           }
@@ -1226,14 +1295,14 @@
       ],
       "position": {
         "start": {
-          "line": 34,
+          "line": 36,
           "column": 1,
-          "offset": 596
+          "offset": 666
         },
         "end": {
-          "line": 34,
+          "line": 36,
           "column": 62,
-          "offset": 657
+          "offset": 727
         },
         "indent": []
       }
@@ -1262,14 +1331,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 664
+                          "offset": 734
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 15,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1277,14 +1346,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 663
+                      "offset": 733
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 16,
-                      "offset": 674
+                      "offset": 744
                     },
                     "indent": []
                   }
@@ -1292,14 +1361,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 663
+                  "offset": 733
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 16,
-                  "offset": 674
+                  "offset": 744
                 },
                 "indent": []
               }
@@ -1307,14 +1376,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 659
+              "offset": 729
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 16,
-              "offset": 674
+              "offset": 744
             },
             "indent": []
           }
@@ -1337,14 +1406,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1354,14 +1423,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "indent": []
                       }
@@ -1371,14 +1440,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 16,
-                          "offset": 690
+                          "offset": 760
                         },
                         "indent": []
                       }
@@ -1386,14 +1455,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 679
+                      "offset": 749
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 17,
-                      "offset": 691
+                      "offset": 761
                     },
                     "indent": []
                   }
@@ -1401,14 +1470,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 679
+                  "offset": 749
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 17,
-                  "offset": 691
+                  "offset": 761
                 },
                 "indent": []
               }
@@ -1416,14 +1485,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 675
+              "offset": 745
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 17,
-              "offset": 691
+              "offset": 761
             },
             "indent": []
           }
@@ -1446,14 +1515,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 697
+                          "offset": 767
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 700
+                          "offset": 770
                         },
                         "indent": []
                       }
@@ -1461,14 +1530,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 696
+                      "offset": 766
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 10,
-                      "offset": 701
+                      "offset": 771
                     },
                     "indent": []
                   }
@@ -1476,14 +1545,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 696
+                  "offset": 766
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 10,
-                  "offset": 701
+                  "offset": 771
                 },
                 "indent": []
               }
@@ -1491,14 +1560,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 692
+              "offset": 762
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 10,
-              "offset": 701
+              "offset": 771
             },
             "indent": []
           }
@@ -1521,14 +1590,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1538,14 +1607,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1555,14 +1624,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 10,
-                          "offset": 711
+                          "offset": 781
                         },
                         "indent": []
                       }
@@ -1570,14 +1639,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 706
+                      "offset": 776
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 11,
-                      "offset": 712
+                      "offset": 782
                     },
                     "indent": []
                   }
@@ -1585,14 +1654,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 706
+                  "offset": 776
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 11,
-                  "offset": 712
+                  "offset": 782
                 },
                 "indent": []
               }
@@ -1600,14 +1669,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 11,
-              "offset": 712
+              "offset": 782
             },
             "indent": []
           }
@@ -1630,14 +1699,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 718
+                          "offset": 788
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "indent": []
                       }
@@ -1647,14 +1716,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "indent": []
                       }
@@ -1664,14 +1733,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 723
+                          "offset": 793
                         },
                         "indent": []
                       }
@@ -1679,14 +1748,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 717
+                      "offset": 787
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 12,
-                      "offset": 724
+                      "offset": 794
                     },
                     "indent": []
                   }
@@ -1694,14 +1763,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 717
+                  "offset": 787
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 12,
-                  "offset": 724
+                  "offset": 794
                 },
                 "indent": []
               }
@@ -1709,14 +1778,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 713
+              "offset": 783
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 12,
-              "offset": 724
+              "offset": 794
             },
             "indent": []
           }
@@ -1739,14 +1808,14 @@
                       "value": "a_a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 6,
-                          "offset": 730
+                          "offset": 800
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 9,
-                          "offset": 733
+                          "offset": 803
                         },
                         "indent": []
                       }
@@ -1756,14 +1825,14 @@
                       "value": "_",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 9,
-                          "offset": 733
+                          "offset": 803
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "indent": []
                       }
@@ -1773,14 +1842,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 12,
-                          "offset": 736
+                          "offset": 806
                         },
                         "indent": []
                       }
@@ -1788,14 +1857,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 41,
+                      "line": 43,
                       "column": 5,
-                      "offset": 729
+                      "offset": 799
                     },
                     "end": {
-                      "line": 41,
+                      "line": 43,
                       "column": 13,
-                      "offset": 737
+                      "offset": 807
                     },
                     "indent": []
                   }
@@ -1803,14 +1872,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
+                  "line": 43,
                   "column": 5,
-                  "offset": 729
+                  "offset": 799
                 },
                 "end": {
-                  "line": 41,
+                  "line": 43,
                   "column": 13,
-                  "offset": 737
+                  "offset": 807
                 },
                 "indent": []
               }
@@ -1818,14 +1887,14 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 43,
               "column": 1,
-              "offset": 725
+              "offset": 795
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 13,
-              "offset": 737
+              "offset": 807
             },
             "indent": []
           }
@@ -1833,14 +1902,14 @@
       ],
       "position": {
         "start": {
-          "line": 36,
+          "line": 38,
           "column": 1,
-          "offset": 659
+          "offset": 729
         },
         "end": {
-          "line": 41,
+          "line": 43,
           "column": 13,
-          "offset": 737
+          "offset": 807
         },
         "indent": [
           1,
@@ -1862,14 +1931,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 43,
+                  "line": 45,
                   "column": 3,
-                  "offset": 741
+                  "offset": 811
                 },
                 "end": {
-                  "line": 43,
+                  "line": 45,
                   "column": 7,
-                  "offset": 745
+                  "offset": 815
                 },
                 "indent": []
               }
@@ -1877,14 +1946,14 @@
           ],
           "position": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 1,
-              "offset": 739
+              "offset": 809
             },
             "end": {
-              "line": 43,
+              "line": 45,
               "column": 9,
-              "offset": 747
+              "offset": 817
             },
             "indent": []
           }
@@ -1892,14 +1961,14 @@
       ],
       "position": {
         "start": {
-          "line": 43,
+          "line": 45,
           "column": 1,
-          "offset": 739
+          "offset": 809
         },
         "end": {
-          "line": 43,
+          "line": 45,
           "column": 9,
-          "offset": 747
+          "offset": 817
         },
         "indent": []
       }
@@ -1912,14 +1981,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 45,
+              "line": 47,
               "column": 1,
-              "offset": 749
+              "offset": 819
             },
             "end": {
-              "line": 45,
+              "line": 47,
               "column": 33,
-              "offset": 781
+              "offset": 851
             },
             "indent": []
           }
@@ -1927,14 +1996,14 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 47,
           "column": 1,
-          "offset": 749
+          "offset": 819
         },
         "end": {
-          "line": 45,
+          "line": 47,
           "column": 33,
-          "offset": 781
+          "offset": 851
         },
         "indent": []
       }
@@ -1958,14 +2027,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 787
+                      "offset": 857
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 9,
-                      "offset": 791
+                      "offset": 861
                     },
                     "indent": []
                   }
@@ -1975,14 +2044,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 9,
-                      "offset": 791
+                      "offset": 861
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 11,
-                      "offset": 793
+                      "offset": 863
                     },
                     "indent": []
                   }
@@ -1992,14 +2061,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 11,
-                      "offset": 793
+                      "offset": 863
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 842
+                      "offset": 912
                     },
                     "indent": []
                   }
@@ -2007,14 +2076,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 787
+                  "offset": 857
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 842
+                  "offset": 912
                 },
                 "indent": []
               }
@@ -2022,14 +2091,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 783
+              "offset": 853
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 842
+              "offset": 912
             },
             "indent": []
           }
@@ -2047,14 +2116,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 5,
-                      "offset": 847
+                      "offset": 917
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 10,
-                      "offset": 852
+                      "offset": 922
                     },
                     "indent": []
                   }
@@ -2064,14 +2133,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 10,
-                      "offset": 852
+                      "offset": 922
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 12,
-                      "offset": 854
+                      "offset": 924
                     },
                     "indent": []
                   }
@@ -2081,14 +2150,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 12,
-                      "offset": 854
+                      "offset": 924
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 61,
-                      "offset": 903
+                      "offset": 973
                     },
                     "indent": []
                   }
@@ -2096,14 +2165,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 48,
+                  "line": 50,
                   "column": 5,
-                  "offset": 847
+                  "offset": 917
                 },
                 "end": {
-                  "line": 48,
+                  "line": 50,
                   "column": 61,
-                  "offset": 903
+                  "offset": 973
                 },
                 "indent": []
               }
@@ -2111,14 +2180,14 @@
           ],
           "position": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 1,
-              "offset": 843
+              "offset": 913
             },
             "end": {
-              "line": 48,
+              "line": 50,
               "column": 61,
-              "offset": 903
+              "offset": 973
             },
             "indent": []
           }
@@ -2136,14 +2205,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 5,
-                      "offset": 908
+                      "offset": 978
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "indent": []
                   }
@@ -2153,14 +2222,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "indent": []
                   }
@@ -2170,14 +2239,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 65,
-                      "offset": 968
+                      "offset": 1038
                     },
                     "indent": []
                   }
@@ -2185,14 +2254,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 51,
                   "column": 5,
-                  "offset": 908
+                  "offset": 978
                 },
                 "end": {
-                  "line": 49,
+                  "line": 51,
                   "column": 65,
-                  "offset": 968
+                  "offset": 1038
                 },
                 "indent": []
               }
@@ -2200,14 +2269,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 904
+              "offset": 974
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 65,
-              "offset": 968
+              "offset": 1038
             },
             "indent": []
           }
@@ -2225,14 +2294,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 5,
-                      "offset": 973
+                      "offset": 1043
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "indent": []
                   }
@@ -2242,14 +2311,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "indent": []
                   }
@@ -2259,14 +2328,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 66,
-                      "offset": 1034
+                      "offset": 1104
                     },
                     "indent": []
                   }
@@ -2274,14 +2343,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 50,
+                  "line": 52,
                   "column": 5,
-                  "offset": 973
+                  "offset": 1043
                 },
                 "end": {
-                  "line": 50,
+                  "line": 52,
                   "column": 66,
-                  "offset": 1034
+                  "offset": 1104
                 },
                 "indent": []
               }
@@ -2289,14 +2358,14 @@
           ],
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 1,
-              "offset": 969
+              "offset": 1039
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 66,
-              "offset": 1034
+              "offset": 1104
             },
             "indent": []
           }
@@ -2304,14 +2373,14 @@
       ],
       "position": {
         "start": {
-          "line": 47,
+          "line": 49,
           "column": 1,
-          "offset": 783
+          "offset": 853
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 66,
-          "offset": 1034
+          "offset": 1104
         },
         "indent": [
           1,
@@ -2328,14 +2397,14 @@
           "value": "Double tildes should be ",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 1036
+              "offset": 1106
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "indent": []
           }
@@ -2345,14 +2414,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "indent": []
           }
@@ -2362,14 +2431,14 @@
           "value": "~escaped",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "indent": []
           }
@@ -2379,14 +2448,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "indent": []
           }
@@ -2396,14 +2465,14 @@
           "value": "~.\nAnd here: foo~~.",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "end": {
-              "line": 53,
+              "line": 55,
               "column": 17,
-              "offset": 1091
+              "offset": 1161
             },
             "indent": [
               1
@@ -2413,14 +2482,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 1036
+          "offset": 1106
         },
         "end": {
-          "line": 53,
+          "line": 55,
           "column": 17,
-          "offset": 1091
+          "offset": 1161
         },
         "indent": [
           1
@@ -2435,14 +2504,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 55,
+              "line": 57,
               "column": 1,
-              "offset": 1093
+              "offset": 1163
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 36,
-              "offset": 1128
+              "offset": 1198
             },
             "indent": []
           }
@@ -2450,14 +2519,14 @@
       ],
       "position": {
         "start": {
-          "line": 55,
+          "line": 57,
           "column": 1,
-          "offset": 1093
+          "offset": 1163
         },
         "end": {
-          "line": 55,
+          "line": 57,
           "column": 36,
-          "offset": 1128
+          "offset": 1198
         },
         "indent": []
       }
@@ -2470,14 +2539,14 @@
           "value": "| here   | they     |\n| ------ | -------- |\n| should | tho",
           "position": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 15,
-              "offset": 1188
+              "offset": 1258
             },
             "indent": [
               1,
@@ -2490,14 +2559,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 59,
+              "line": 61,
               "column": 15,
-              "offset": 1188
+              "offset": 1258
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 17,
-              "offset": 1190
+              "offset": 1260
             },
             "indent": []
           }
@@ -2507,14 +2576,14 @@
           "value": "ugh |",
           "position": {
             "start": {
-              "line": 59,
+              "line": 61,
               "column": 17,
-              "offset": 1190
+              "offset": 1260
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 22,
-              "offset": 1195
+              "offset": 1265
             },
             "indent": []
           }
@@ -2522,14 +2591,14 @@
       ],
       "position": {
         "start": {
-          "line": 57,
+          "line": 59,
           "column": 1,
-          "offset": 1130
+          "offset": 1200
         },
         "end": {
-          "line": 59,
+          "line": 61,
           "column": 22,
-          "offset": 1195
+          "offset": 1265
         },
         "indent": [
           1,
@@ -2545,14 +2614,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1197
+              "offset": 1267
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 10,
-              "offset": 1206
+              "offset": 1276
             },
             "indent": []
           }
@@ -2560,14 +2629,14 @@
       ],
       "position": {
         "start": {
-          "line": 61,
+          "line": 63,
           "column": 1,
-          "offset": 1197
+          "offset": 1267
         },
         "end": {
-          "line": 61,
+          "line": 63,
           "column": 10,
-          "offset": 1206
+          "offset": 1276
         },
         "indent": []
       }
@@ -2580,14 +2649,14 @@
           "value": "| here   | they   |\n",
           "position": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 1,
-              "offset": 1208
+              "offset": 1278
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "indent": [
               1
@@ -2599,14 +2668,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "indent": []
           }
@@ -2616,14 +2685,14 @@
           "value": " ---- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "indent": []
           }
@@ -2633,14 +2702,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "indent": []
           }
@@ -2650,14 +2719,14 @@
           "value": " ----- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "indent": []
           }
@@ -2667,14 +2736,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "indent": []
           }
@@ -2684,14 +2753,14 @@
           "value": "\n| should | though |",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "end": {
-              "line": 65,
+              "line": 67,
               "column": 20,
-              "offset": 1267
+              "offset": 1337
             },
             "indent": [
               1
@@ -2701,14 +2770,14 @@
       ],
       "position": {
         "start": {
-          "line": 63,
+          "line": 65,
           "column": 1,
-          "offset": 1208
+          "offset": 1278
         },
         "end": {
-          "line": 65,
+          "line": 67,
           "column": 20,
-          "offset": 1267
+          "offset": 1337
         },
         "indent": [
           1,
@@ -2724,14 +2793,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1269
+              "offset": 1339
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 10,
-              "offset": 1278
+              "offset": 1348
             },
             "indent": []
           }
@@ -2739,14 +2808,14 @@
       ],
       "position": {
         "start": {
-          "line": 67,
+          "line": 69,
           "column": 1,
-          "offset": 1269
+          "offset": 1339
         },
         "end": {
-          "line": 67,
+          "line": 69,
           "column": 10,
-          "offset": 1278
+          "offset": 1348
         },
         "indent": []
       }
@@ -2759,14 +2828,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 69,
+              "line": 71,
               "column": 1,
-              "offset": 1280
+              "offset": 1350
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "indent": [
               1
@@ -2778,14 +2847,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "indent": []
           }
@@ -2795,14 +2864,14 @@
           "value": "--- ",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "indent": []
           }
@@ -2812,14 +2881,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "indent": []
           }
@@ -2829,14 +2898,14 @@
           "value": " ------\nshould | though",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "end": {
-              "line": 71,
+              "line": 73,
               "column": 16,
-              "offset": 1325
+              "offset": 1395
             },
             "indent": [
               1
@@ -2846,14 +2915,14 @@
       ],
       "position": {
         "start": {
-          "line": 69,
+          "line": 71,
           "column": 1,
-          "offset": 1280
+          "offset": 1350
         },
         "end": {
-          "line": 71,
+          "line": 73,
           "column": 16,
-          "offset": 1325
+          "offset": 1395
         },
         "indent": [
           1,
@@ -2872,14 +2941,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 73,
+                  "line": 75,
                   "column": 3,
-                  "offset": 1329
+                  "offset": 1399
                 },
                 "end": {
-                  "line": 73,
+                  "line": 75,
                   "column": 14,
-                  "offset": 1340
+                  "offset": 1410
                 },
                 "indent": []
               }
@@ -2887,14 +2956,14 @@
           ],
           "position": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 1,
-              "offset": 1327
+              "offset": 1397
             },
             "end": {
-              "line": 73,
+              "line": 75,
               "column": 16,
-              "offset": 1342
+              "offset": 1412
             },
             "indent": []
           }
@@ -2902,14 +2971,14 @@
       ],
       "position": {
         "start": {
-          "line": 73,
+          "line": 75,
           "column": 1,
-          "offset": 1327
+          "offset": 1397
         },
         "end": {
-          "line": 73,
+          "line": 75,
           "column": 16,
-          "offset": 1342
+          "offset": 1412
         },
         "indent": []
       }
@@ -2922,14 +2991,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1344
+              "offset": 1414
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 38,
-              "offset": 1381
+              "offset": 1451
             },
             "indent": []
           }
@@ -2937,14 +3006,14 @@
       ],
       "position": {
         "start": {
-          "line": 75,
+          "line": 77,
           "column": 1,
-          "offset": 1344
+          "offset": 1414
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 38,
-          "offset": 1381
+          "offset": 1451
         },
         "indent": []
       }
@@ -2968,14 +3037,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 5,
-                      "offset": 1387
+                      "offset": 1457
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 7,
-                      "offset": 1389
+                      "offset": 1459
                     },
                     "indent": []
                   }
@@ -2985,14 +3054,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 7,
-                      "offset": 1389
+                      "offset": 1459
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "indent": []
                   }
@@ -3002,14 +3071,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 13,
-                      "offset": 1395
+                      "offset": 1465
                     },
                     "indent": []
                   }
@@ -3019,14 +3088,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 13,
-                      "offset": 1395
+                      "offset": 1465
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 18,
-                      "offset": 1400
+                      "offset": 1470
                     },
                     "indent": []
                   }
@@ -3034,14 +3103,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 77,
+                  "line": 79,
                   "column": 5,
-                  "offset": 1387
+                  "offset": 1457
                 },
                 "end": {
-                  "line": 77,
+                  "line": 79,
                   "column": 18,
-                  "offset": 1400
+                  "offset": 1470
                 },
                 "indent": []
               }
@@ -3049,14 +3118,14 @@
           ],
           "position": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 1,
-              "offset": 1383
+              "offset": 1453
             },
             "end": {
-              "line": 77,
+              "line": 79,
               "column": 18,
-              "offset": 1400
+              "offset": 1470
             },
             "indent": []
           }
@@ -3074,292 +3143,80 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 78,
+                      "line": 80,
                       "column": 5,
-                      "offset": 1405
+                      "offset": 1475
                     },
                     "end": {
-                      "line": 78,
+                      "line": 80,
                       "column": 7,
-                      "offset": 1407
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "http",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 7,
-                      "offset": 1407
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 11,
-                      "offset": 1411
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 11,
-                      "offset": 1411
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 13,
-                      "offset": 1413
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "google.com>",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 13,
-                      "offset": 1413
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 24,
-                      "offset": 1424
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 78,
-                  "column": 5,
-                  "offset": 1405
-                },
-                "end": {
-                  "line": 78,
-                  "column": 24,
-                  "offset": 1424
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 78,
-              "column": 1,
-              "offset": 1401
-            },
-            "end": {
-              "line": 78,
-              "column": 24,
-              "offset": 1424
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 5,
-                      "offset": 1429
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 9,
-                      "offset": 1433
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "div>",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 9,
-                      "offset": 1433
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 13,
-                      "offset": 1437
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 13,
-                      "offset": 1437
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 17,
-                      "offset": 1441
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "/div>",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 17,
-                      "offset": 1441
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 22,
-                      "offset": 1446
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 79,
-                  "column": 5,
-                  "offset": 1429
-                },
-                "end": {
-                  "line": 79,
-                  "column": 22,
-                  "offset": 1446
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 79,
-              "column": 1,
-              "offset": 1425
-            },
-            "end": {
-              "line": 79,
-              "column": 22,
-              "offset": 1446
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 5,
-                      "offset": 1451
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 9,
-                      "offset": 1455
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "http",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 9,
-                      "offset": 1455
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 13,
-                      "offset": 1459
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 13,
-                      "offset": 1459
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 20,
-                      "offset": 1466
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "google.com>",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 20,
-                      "offset": 1466
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 31,
                       "offset": 1477
                     },
                     "indent": []
                   }
+                },
+                {
+                  "type": "text",
+                  "value": "http",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 7,
+                      "offset": 1477
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 11,
+                      "offset": 1481
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 11,
+                      "offset": 1481
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 13,
+                      "offset": 1483
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "google.com>",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 13,
+                      "offset": 1483
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 24,
+                      "offset": 1494
+                    },
+                    "indent": []
+                  }
                 }
               ],
               "position": {
                 "start": {
                   "line": 80,
                   "column": 5,
-                  "offset": 1451
+                  "offset": 1475
                 },
                 "end": {
                   "line": 80,
-                  "column": 31,
-                  "offset": 1477
+                  "column": 24,
+                  "offset": 1494
                 },
                 "indent": []
               }
@@ -3369,12 +3226,224 @@
             "start": {
               "line": 80,
               "column": 1,
-              "offset": 1447
+              "offset": 1471
             },
             "end": {
               "line": 80,
+              "column": 24,
+              "offset": 1494
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 5,
+                      "offset": 1499
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 9,
+                      "offset": 1503
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "div>",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 9,
+                      "offset": 1503
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 13,
+                      "offset": 1507
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 13,
+                      "offset": 1507
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 17,
+                      "offset": 1511
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "/div>",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 17,
+                      "offset": 1511
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 22,
+                      "offset": 1516
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 81,
+                  "column": 5,
+                  "offset": 1499
+                },
+                "end": {
+                  "line": 81,
+                  "column": 22,
+                  "offset": 1516
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 81,
+              "column": 1,
+              "offset": 1495
+            },
+            "end": {
+              "line": 81,
+              "column": 22,
+              "offset": 1516
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 5,
+                      "offset": 1521
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 9,
+                      "offset": 1525
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "http",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 9,
+                      "offset": 1525
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 13,
+                      "offset": 1529
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 13,
+                      "offset": 1529
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 20,
+                      "offset": 1536
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "google.com>",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 20,
+                      "offset": 1536
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 31,
+                      "offset": 1547
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 82,
+                  "column": 5,
+                  "offset": 1521
+                },
+                "end": {
+                  "line": 82,
+                  "column": 31,
+                  "offset": 1547
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 82,
+              "column": 1,
+              "offset": 1517
+            },
+            "end": {
+              "line": 82,
               "column": 31,
-              "offset": 1477
+              "offset": 1547
             },
             "indent": []
           }
@@ -3382,14 +3451,14 @@
       ],
       "position": {
         "start": {
-          "line": 77,
+          "line": 79,
           "column": 1,
-          "offset": 1383
+          "offset": 1453
         },
         "end": {
-          "line": 80,
+          "line": 82,
           "column": 31,
-          "offset": 1477
+          "offset": 1547
         },
         "indent": [
           1,
@@ -3406,9 +3475,9 @@
       "offset": 0
     },
     "end": {
-      "line": 81,
+      "line": 83,
       "column": 1,
-      "offset": 1478
+      "offset": 1548
     }
   }
 }

--- a/test/tree/stringify-escape.nogfm.commonmark.pedantic.json
+++ b/test/tree/stringify-escape.nogfm.commonmark.pedantic.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,219 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 50,
+              "offset": 163
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "emphasis",
+          "children": [
+            {
+              "type": "text",
+              "value": "the",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 51,
+                  "offset": 164
+                },
+                "end": {
+                  "line": 9,
+                  "column": 54,
+                  "offset": 167
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 50,
+              "offset": 163
+            },
+            "end": {
+              "line": 9,
+              "column": 55,
+              "offset": 168
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "middle",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 55,
+              "offset": 168
+            },
+            "end": {
+              "line": 9,
+              "column": 61,
+              "offset": 174
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "emphasis",
+          "children": [
+            {
+              "type": "text",
+              "value": "of",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 62,
+                  "offset": 175
+                },
+                "end": {
+                  "line": 9,
+                  "column": 64,
+                  "offset": 177
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 61,
+              "offset": 174
+            },
+            "end": {
+              "line": 9,
+              "column": 65,
+              "offset": 178
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 65,
+              "offset": 178
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +458,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +473,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +504,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "indent": []
                   }
@@ -348,14 +521,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "indent": []
                   }
@@ -365,14 +538,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "indent": []
                   }
@@ -382,14 +555,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "indent": []
                   }
@@ -399,14 +572,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "indent": []
                   }
@@ -416,14 +589,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +604,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +619,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +644,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "indent": []
                   }
@@ -488,14 +661,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "indent": []
                   }
@@ -505,14 +678,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "indent": []
                   }
@@ -522,14 +695,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "indent": []
                   }
@@ -539,14 +712,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "indent": []
                   }
@@ -556,14 +729,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 37,
-                      "offset": 253
+                      "offset": 323
                     },
                     "indent": []
                   }
@@ -571,14 +744,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 37,
-                  "offset": 253
+                  "offset": 323
                 },
                 "indent": []
               }
@@ -586,14 +759,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 37,
-              "offset": 253
+              "offset": 323
             },
             "indent": []
           }
@@ -611,14 +784,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 5,
-                      "offset": 258
+                      "offset": 328
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "indent": []
                   }
@@ -628,14 +801,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "indent": []
                   }
@@ -645,14 +818,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 43,
-                      "offset": 296
+                      "offset": 366
                     },
                     "indent": []
                   }
@@ -660,14 +833,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 13,
+                  "line": 15,
                   "column": 5,
-                  "offset": 258
+                  "offset": 328
                 },
                 "end": {
-                  "line": 13,
+                  "line": 15,
                   "column": 43,
-                  "offset": 296
+                  "offset": 366
                 },
                 "indent": []
               }
@@ -675,14 +848,14 @@
           ],
           "position": {
             "start": {
-              "line": 13,
+              "line": 15,
               "column": 1,
-              "offset": 254
+              "offset": 324
             },
             "end": {
-              "line": 13,
+              "line": 15,
               "column": 43,
-              "offset": 296
+              "offset": 366
             },
             "indent": []
           }
@@ -690,14 +863,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 13,
+          "line": 15,
           "column": 43,
-          "offset": 296
+          "offset": 366
         },
         "indent": [
           1,
@@ -713,14 +886,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 15,
+              "line": 17,
               "column": 1,
-              "offset": 298
+              "offset": 368
             },
             "end": {
-              "line": 15,
+              "line": 17,
               "column": 63,
-              "offset": 360
+              "offset": 430
             },
             "indent": []
           }
@@ -728,14 +901,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 17,
           "column": 1,
-          "offset": 298
+          "offset": 368
         },
         "end": {
-          "line": 15,
+          "line": 17,
           "column": 63,
-          "offset": 360
+          "offset": 430
         },
         "indent": []
       }
@@ -753,14 +926,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 17,
+                  "line": 19,
                   "column": 2,
-                  "offset": 363
+                  "offset": 433
                 },
                 "end": {
-                  "line": 17,
+                  "line": 19,
                   "column": 5,
-                  "offset": 366
+                  "offset": 436
                 },
                 "indent": []
               }
@@ -768,14 +941,14 @@
           ],
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 1,
-              "offset": 362
+              "offset": 432
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "indent": []
           }
@@ -785,14 +958,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "indent": []
           }
@@ -802,14 +975,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 13,
-              "offset": 374
+              "offset": 444
             },
             "indent": []
           }
@@ -817,14 +990,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 19,
           "column": 1,
-          "offset": 362
+          "offset": 432
         },
         "end": {
-          "line": 17,
+          "line": 19,
           "column": 13,
-          "offset": 374
+          "offset": 444
         },
         "indent": []
       }
@@ -837,14 +1010,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 19,
+              "line": 21,
               "column": 1,
-              "offset": 376
+              "offset": 446
             },
             "end": {
-              "line": 19,
+              "line": 21,
               "column": 53,
-              "offset": 428
+              "offset": 498
             },
             "indent": []
           }
@@ -852,14 +1025,14 @@
       ],
       "position": {
         "start": {
-          "line": 19,
+          "line": 21,
           "column": 1,
-          "offset": 376
+          "offset": 446
         },
         "end": {
-          "line": 19,
+          "line": 21,
           "column": 53,
-          "offset": 428
+          "offset": 498
         },
         "indent": []
       }
@@ -872,14 +1045,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 430
+              "offset": 500
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "indent": []
           }
@@ -889,14 +1062,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "indent": [
               1
@@ -908,14 +1081,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -925,14 +1098,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "indent": [
               1
@@ -944,14 +1117,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "indent": []
           }
@@ -961,14 +1134,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 21,
-              "offset": 488
+              "offset": 558
             },
             "indent": []
           }
@@ -976,14 +1149,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 23,
           "column": 1,
-          "offset": 430
+          "offset": 500
         },
         "end": {
-          "line": 23,
+          "line": 25,
           "column": 21,
-          "offset": 488
+          "offset": 558
         },
         "indent": [
           1,
@@ -999,14 +1172,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 1,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 25,
+              "line": 27,
               "column": 25,
-              "offset": 514
+              "offset": 584
             },
             "indent": []
           }
@@ -1014,14 +1187,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 27,
           "column": 1,
-          "offset": 490
+          "offset": 560
         },
         "end": {
-          "line": 25,
+          "line": 27,
           "column": 25,
-          "offset": 514
+          "offset": 584
         },
         "indent": []
       }
@@ -1034,14 +1207,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 1,
-              "offset": 516
+              "offset": 586
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "indent": []
           }
@@ -1051,14 +1224,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 21,
-              "offset": 536
+              "offset": 606
             },
             "indent": []
           }
@@ -1066,14 +1239,14 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 29,
           "column": 1,
-          "offset": 516
+          "offset": 586
         },
         "end": {
-          "line": 27,
+          "line": 29,
           "column": 21,
-          "offset": 536
+          "offset": 606
         },
         "indent": []
       }
@@ -1086,14 +1259,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 29,
+              "line": 31,
               "column": 1,
-              "offset": 538
+              "offset": 608
             },
             "end": {
-              "line": 29,
+              "line": 31,
               "column": 16,
-              "offset": 553
+              "offset": 623
             },
             "indent": []
           }
@@ -1101,14 +1274,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 31,
           "column": 1,
-          "offset": 538
+          "offset": 608
         },
         "end": {
-          "line": 29,
+          "line": 31,
           "column": 16,
-          "offset": 553
+          "offset": 623
         },
         "indent": []
       }
@@ -1121,14 +1294,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 1,
-              "offset": 555
+              "offset": 625
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1138,14 +1311,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "indent": [
               1
@@ -1157,14 +1330,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "indent": []
           }
@@ -1174,14 +1347,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 23,
-              "offset": 594
+              "offset": 664
             },
             "indent": []
           }
@@ -1189,14 +1362,14 @@
       ],
       "position": {
         "start": {
-          "line": 31,
+          "line": 33,
           "column": 1,
-          "offset": 555
+          "offset": 625
         },
         "end": {
-          "line": 32,
+          "line": 34,
           "column": 23,
-          "offset": 594
+          "offset": 664
         },
         "indent": [
           1
@@ -1211,14 +1384,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 1,
-              "offset": 596
+              "offset": 666
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 62,
-              "offset": 657
+              "offset": 727
             },
             "indent": []
           }
@@ -1226,14 +1399,14 @@
       ],
       "position": {
         "start": {
-          "line": 34,
+          "line": 36,
           "column": 1,
-          "offset": 596
+          "offset": 666
         },
         "end": {
-          "line": 34,
+          "line": 36,
           "column": 62,
-          "offset": 657
+          "offset": 727
         },
         "indent": []
       }
@@ -1262,14 +1435,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 664
+                          "offset": 734
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 15,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1277,14 +1450,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 663
+                      "offset": 733
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 16,
-                      "offset": 674
+                      "offset": 744
                     },
                     "indent": []
                   }
@@ -1292,14 +1465,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 663
+                  "offset": 733
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 16,
-                  "offset": 674
+                  "offset": 744
                 },
                 "indent": []
               }
@@ -1307,14 +1480,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 659
+              "offset": 729
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 16,
-              "offset": 674
+              "offset": 744
             },
             "indent": []
           }
@@ -1337,14 +1510,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1354,14 +1527,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "indent": []
                       }
@@ -1371,14 +1544,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 16,
-                          "offset": 690
+                          "offset": 760
                         },
                         "indent": []
                       }
@@ -1386,14 +1559,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 679
+                      "offset": 749
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 17,
-                      "offset": 691
+                      "offset": 761
                     },
                     "indent": []
                   }
@@ -1401,14 +1574,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 679
+                  "offset": 749
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 17,
-                  "offset": 691
+                  "offset": 761
                 },
                 "indent": []
               }
@@ -1416,14 +1589,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 675
+              "offset": 745
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 17,
-              "offset": 691
+              "offset": 761
             },
             "indent": []
           }
@@ -1446,14 +1619,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 697
+                          "offset": 767
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 700
+                          "offset": 770
                         },
                         "indent": []
                       }
@@ -1461,14 +1634,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 696
+                      "offset": 766
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 10,
-                      "offset": 701
+                      "offset": 771
                     },
                     "indent": []
                   }
@@ -1476,14 +1649,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 696
+                  "offset": 766
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 10,
-                  "offset": 701
+                  "offset": 771
                 },
                 "indent": []
               }
@@ -1491,14 +1664,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 692
+              "offset": 762
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 10,
-              "offset": 701
+              "offset": 771
             },
             "indent": []
           }
@@ -1521,14 +1694,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1538,14 +1711,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1555,14 +1728,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 10,
-                          "offset": 711
+                          "offset": 781
                         },
                         "indent": []
                       }
@@ -1570,14 +1743,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 706
+                      "offset": 776
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 11,
-                      "offset": 712
+                      "offset": 782
                     },
                     "indent": []
                   }
@@ -1585,14 +1758,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 706
+                  "offset": 776
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 11,
-                  "offset": 712
+                  "offset": 782
                 },
                 "indent": []
               }
@@ -1600,14 +1773,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 11,
-              "offset": 712
+              "offset": 782
             },
             "indent": []
           }
@@ -1630,14 +1803,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 718
+                          "offset": 788
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "indent": []
                       }
@@ -1647,14 +1820,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "indent": []
                       }
@@ -1664,14 +1837,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 723
+                          "offset": 793
                         },
                         "indent": []
                       }
@@ -1679,14 +1852,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 717
+                      "offset": 787
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 12,
-                      "offset": 724
+                      "offset": 794
                     },
                     "indent": []
                   }
@@ -1694,14 +1867,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 717
+                  "offset": 787
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 12,
-                  "offset": 724
+                  "offset": 794
                 },
                 "indent": []
               }
@@ -1709,14 +1882,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 713
+              "offset": 783
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 12,
-              "offset": 724
+              "offset": 794
             },
             "indent": []
           }
@@ -1739,14 +1912,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 6,
-                          "offset": 730
+                          "offset": 800
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 7,
-                          "offset": 731
+                          "offset": 801
                         },
                         "indent": []
                       }
@@ -1759,14 +1932,14 @@
                           "value": "a\\",
                           "position": {
                             "start": {
-                              "line": 41,
+                              "line": 43,
                               "column": 8,
-                              "offset": 732
+                              "offset": 802
                             },
                             "end": {
-                              "line": 41,
+                              "line": 43,
                               "column": 10,
-                              "offset": 734
+                              "offset": 804
                             },
                             "indent": []
                           }
@@ -1774,14 +1947,14 @@
                       ],
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 7,
-                          "offset": 731
+                          "offset": 801
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "indent": []
                       }
@@ -1791,14 +1964,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 12,
-                          "offset": 736
+                          "offset": 806
                         },
                         "indent": []
                       }
@@ -1806,14 +1979,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 41,
+                      "line": 43,
                       "column": 5,
-                      "offset": 729
+                      "offset": 799
                     },
                     "end": {
-                      "line": 41,
+                      "line": 43,
                       "column": 13,
-                      "offset": 737
+                      "offset": 807
                     },
                     "indent": []
                   }
@@ -1821,14 +1994,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
+                  "line": 43,
                   "column": 5,
-                  "offset": 729
+                  "offset": 799
                 },
                 "end": {
-                  "line": 41,
+                  "line": 43,
                   "column": 13,
-                  "offset": 737
+                  "offset": 807
                 },
                 "indent": []
               }
@@ -1836,14 +2009,14 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 43,
               "column": 1,
-              "offset": 725
+              "offset": 795
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 13,
-              "offset": 737
+              "offset": 807
             },
             "indent": []
           }
@@ -1851,14 +2024,14 @@
       ],
       "position": {
         "start": {
-          "line": 36,
+          "line": 38,
           "column": 1,
-          "offset": 659
+          "offset": 729
         },
         "end": {
-          "line": 41,
+          "line": 43,
           "column": 13,
-          "offset": 737
+          "offset": 807
         },
         "indent": [
           1,
@@ -1880,14 +2053,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 43,
+                  "line": 45,
                   "column": 3,
-                  "offset": 741
+                  "offset": 811
                 },
                 "end": {
-                  "line": 43,
+                  "line": 45,
                   "column": 7,
-                  "offset": 745
+                  "offset": 815
                 },
                 "indent": []
               }
@@ -1895,14 +2068,14 @@
           ],
           "position": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 1,
-              "offset": 739
+              "offset": 809
             },
             "end": {
-              "line": 43,
+              "line": 45,
               "column": 9,
-              "offset": 747
+              "offset": 817
             },
             "indent": []
           }
@@ -1910,14 +2083,14 @@
       ],
       "position": {
         "start": {
-          "line": 43,
+          "line": 45,
           "column": 1,
-          "offset": 739
+          "offset": 809
         },
         "end": {
-          "line": 43,
+          "line": 45,
           "column": 9,
-          "offset": 747
+          "offset": 817
         },
         "indent": []
       }
@@ -1930,14 +2103,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 45,
+              "line": 47,
               "column": 1,
-              "offset": 749
+              "offset": 819
             },
             "end": {
-              "line": 45,
+              "line": 47,
               "column": 33,
-              "offset": 781
+              "offset": 851
             },
             "indent": []
           }
@@ -1945,14 +2118,14 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 47,
           "column": 1,
-          "offset": 749
+          "offset": 819
         },
         "end": {
-          "line": 45,
+          "line": 47,
           "column": 33,
-          "offset": 781
+          "offset": 851
         },
         "indent": []
       }
@@ -1976,14 +2149,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 787
+                      "offset": 857
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 9,
-                      "offset": 791
+                      "offset": 861
                     },
                     "indent": []
                   }
@@ -1993,14 +2166,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 9,
-                      "offset": 791
+                      "offset": 861
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 11,
-                      "offset": 793
+                      "offset": 863
                     },
                     "indent": []
                   }
@@ -2010,14 +2183,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 11,
-                      "offset": 793
+                      "offset": 863
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 842
+                      "offset": 912
                     },
                     "indent": []
                   }
@@ -2025,14 +2198,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 787
+                  "offset": 857
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 842
+                  "offset": 912
                 },
                 "indent": []
               }
@@ -2040,14 +2213,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 783
+              "offset": 853
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 842
+              "offset": 912
             },
             "indent": []
           }
@@ -2065,14 +2238,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 5,
-                      "offset": 847
+                      "offset": 917
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 10,
-                      "offset": 852
+                      "offset": 922
                     },
                     "indent": []
                   }
@@ -2082,14 +2255,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 10,
-                      "offset": 852
+                      "offset": 922
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 12,
-                      "offset": 854
+                      "offset": 924
                     },
                     "indent": []
                   }
@@ -2099,14 +2272,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 12,
-                      "offset": 854
+                      "offset": 924
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 61,
-                      "offset": 903
+                      "offset": 973
                     },
                     "indent": []
                   }
@@ -2114,14 +2287,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 48,
+                  "line": 50,
                   "column": 5,
-                  "offset": 847
+                  "offset": 917
                 },
                 "end": {
-                  "line": 48,
+                  "line": 50,
                   "column": 61,
-                  "offset": 903
+                  "offset": 973
                 },
                 "indent": []
               }
@@ -2129,14 +2302,14 @@
           ],
           "position": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 1,
-              "offset": 843
+              "offset": 913
             },
             "end": {
-              "line": 48,
+              "line": 50,
               "column": 61,
-              "offset": 903
+              "offset": 973
             },
             "indent": []
           }
@@ -2154,14 +2327,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 5,
-                      "offset": 908
+                      "offset": 978
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "indent": []
                   }
@@ -2171,14 +2344,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "indent": []
                   }
@@ -2188,14 +2361,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 65,
-                      "offset": 968
+                      "offset": 1038
                     },
                     "indent": []
                   }
@@ -2203,14 +2376,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 51,
                   "column": 5,
-                  "offset": 908
+                  "offset": 978
                 },
                 "end": {
-                  "line": 49,
+                  "line": 51,
                   "column": 65,
-                  "offset": 968
+                  "offset": 1038
                 },
                 "indent": []
               }
@@ -2218,14 +2391,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 904
+              "offset": 974
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 65,
-              "offset": 968
+              "offset": 1038
             },
             "indent": []
           }
@@ -2243,14 +2416,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 5,
-                      "offset": 973
+                      "offset": 1043
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "indent": []
                   }
@@ -2260,14 +2433,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "indent": []
                   }
@@ -2277,14 +2450,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 66,
-                      "offset": 1034
+                      "offset": 1104
                     },
                     "indent": []
                   }
@@ -2292,14 +2465,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 50,
+                  "line": 52,
                   "column": 5,
-                  "offset": 973
+                  "offset": 1043
                 },
                 "end": {
-                  "line": 50,
+                  "line": 52,
                   "column": 66,
-                  "offset": 1034
+                  "offset": 1104
                 },
                 "indent": []
               }
@@ -2307,14 +2480,14 @@
           ],
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 1,
-              "offset": 969
+              "offset": 1039
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 66,
-              "offset": 1034
+              "offset": 1104
             },
             "indent": []
           }
@@ -2322,14 +2495,14 @@
       ],
       "position": {
         "start": {
-          "line": 47,
+          "line": 49,
           "column": 1,
-          "offset": 783
+          "offset": 853
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 66,
-          "offset": 1034
+          "offset": 1104
         },
         "indent": [
           1,
@@ -2346,14 +2519,14 @@
           "value": "Double tildes should be ",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 1036
+              "offset": 1106
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "indent": []
           }
@@ -2363,14 +2536,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "indent": []
           }
@@ -2380,14 +2553,14 @@
           "value": "~escaped",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "indent": []
           }
@@ -2397,14 +2570,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "indent": []
           }
@@ -2414,14 +2587,14 @@
           "value": "~.\nAnd here: foo~~.",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "end": {
-              "line": 53,
+              "line": 55,
               "column": 17,
-              "offset": 1091
+              "offset": 1161
             },
             "indent": [
               1
@@ -2431,14 +2604,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 1036
+          "offset": 1106
         },
         "end": {
-          "line": 53,
+          "line": 55,
           "column": 17,
-          "offset": 1091
+          "offset": 1161
         },
         "indent": [
           1
@@ -2453,14 +2626,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 55,
+              "line": 57,
               "column": 1,
-              "offset": 1093
+              "offset": 1163
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 36,
-              "offset": 1128
+              "offset": 1198
             },
             "indent": []
           }
@@ -2468,14 +2641,14 @@
       ],
       "position": {
         "start": {
-          "line": 55,
+          "line": 57,
           "column": 1,
-          "offset": 1093
+          "offset": 1163
         },
         "end": {
-          "line": 55,
+          "line": 57,
           "column": 36,
-          "offset": 1128
+          "offset": 1198
         },
         "indent": []
       }
@@ -2488,14 +2661,14 @@
           "value": "| here   | they     |\n| ------ | -------- |\n| should | tho",
           "position": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 15,
-              "offset": 1188
+              "offset": 1258
             },
             "indent": [
               1,
@@ -2508,14 +2681,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 59,
+              "line": 61,
               "column": 15,
-              "offset": 1188
+              "offset": 1258
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 17,
-              "offset": 1190
+              "offset": 1260
             },
             "indent": []
           }
@@ -2525,14 +2698,14 @@
           "value": "ugh |",
           "position": {
             "start": {
-              "line": 59,
+              "line": 61,
               "column": 17,
-              "offset": 1190
+              "offset": 1260
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 22,
-              "offset": 1195
+              "offset": 1265
             },
             "indent": []
           }
@@ -2540,14 +2713,14 @@
       ],
       "position": {
         "start": {
-          "line": 57,
+          "line": 59,
           "column": 1,
-          "offset": 1130
+          "offset": 1200
         },
         "end": {
-          "line": 59,
+          "line": 61,
           "column": 22,
-          "offset": 1195
+          "offset": 1265
         },
         "indent": [
           1,
@@ -2563,14 +2736,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1197
+              "offset": 1267
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 10,
-              "offset": 1206
+              "offset": 1276
             },
             "indent": []
           }
@@ -2578,14 +2751,14 @@
       ],
       "position": {
         "start": {
-          "line": 61,
+          "line": 63,
           "column": 1,
-          "offset": 1197
+          "offset": 1267
         },
         "end": {
-          "line": 61,
+          "line": 63,
           "column": 10,
-          "offset": 1206
+          "offset": 1276
         },
         "indent": []
       }
@@ -2598,14 +2771,14 @@
           "value": "| here   | they   |\n",
           "position": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 1,
-              "offset": 1208
+              "offset": 1278
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "indent": [
               1
@@ -2617,14 +2790,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "indent": []
           }
@@ -2634,14 +2807,14 @@
           "value": " ---- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "indent": []
           }
@@ -2651,14 +2824,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "indent": []
           }
@@ -2668,14 +2841,14 @@
           "value": " ----- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "indent": []
           }
@@ -2685,14 +2858,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "indent": []
           }
@@ -2702,14 +2875,14 @@
           "value": "\n| should | though |",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "end": {
-              "line": 65,
+              "line": 67,
               "column": 20,
-              "offset": 1267
+              "offset": 1337
             },
             "indent": [
               1
@@ -2719,14 +2892,14 @@
       ],
       "position": {
         "start": {
-          "line": 63,
+          "line": 65,
           "column": 1,
-          "offset": 1208
+          "offset": 1278
         },
         "end": {
-          "line": 65,
+          "line": 67,
           "column": 20,
-          "offset": 1267
+          "offset": 1337
         },
         "indent": [
           1,
@@ -2742,14 +2915,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1269
+              "offset": 1339
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 10,
-              "offset": 1278
+              "offset": 1348
             },
             "indent": []
           }
@@ -2757,14 +2930,14 @@
       ],
       "position": {
         "start": {
-          "line": 67,
+          "line": 69,
           "column": 1,
-          "offset": 1269
+          "offset": 1339
         },
         "end": {
-          "line": 67,
+          "line": 69,
           "column": 10,
-          "offset": 1278
+          "offset": 1348
         },
         "indent": []
       }
@@ -2777,14 +2950,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 69,
+              "line": 71,
               "column": 1,
-              "offset": 1280
+              "offset": 1350
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "indent": [
               1
@@ -2796,14 +2969,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "indent": []
           }
@@ -2813,14 +2986,14 @@
           "value": "--- ",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "indent": []
           }
@@ -2830,14 +3003,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "indent": []
           }
@@ -2847,14 +3020,14 @@
           "value": " ------\nshould | though",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "end": {
-              "line": 71,
+              "line": 73,
               "column": 16,
-              "offset": 1325
+              "offset": 1395
             },
             "indent": [
               1
@@ -2864,14 +3037,14 @@
       ],
       "position": {
         "start": {
-          "line": 69,
+          "line": 71,
           "column": 1,
-          "offset": 1280
+          "offset": 1350
         },
         "end": {
-          "line": 71,
+          "line": 73,
           "column": 16,
-          "offset": 1325
+          "offset": 1395
         },
         "indent": [
           1,
@@ -2890,14 +3063,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 73,
+                  "line": 75,
                   "column": 3,
-                  "offset": 1329
+                  "offset": 1399
                 },
                 "end": {
-                  "line": 73,
+                  "line": 75,
                   "column": 14,
-                  "offset": 1340
+                  "offset": 1410
                 },
                 "indent": []
               }
@@ -2905,14 +3078,14 @@
           ],
           "position": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 1,
-              "offset": 1327
+              "offset": 1397
             },
             "end": {
-              "line": 73,
+              "line": 75,
               "column": 16,
-              "offset": 1342
+              "offset": 1412
             },
             "indent": []
           }
@@ -2920,14 +3093,14 @@
       ],
       "position": {
         "start": {
-          "line": 73,
+          "line": 75,
           "column": 1,
-          "offset": 1327
+          "offset": 1397
         },
         "end": {
-          "line": 73,
+          "line": 75,
           "column": 16,
-          "offset": 1342
+          "offset": 1412
         },
         "indent": []
       }
@@ -2940,14 +3113,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1344
+              "offset": 1414
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 38,
-              "offset": 1381
+              "offset": 1451
             },
             "indent": []
           }
@@ -2955,14 +3128,14 @@
       ],
       "position": {
         "start": {
-          "line": 75,
+          "line": 77,
           "column": 1,
-          "offset": 1344
+          "offset": 1414
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 38,
-          "offset": 1381
+          "offset": 1451
         },
         "indent": []
       }
@@ -2986,14 +3159,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 5,
-                      "offset": 1387
+                      "offset": 1457
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 7,
-                      "offset": 1389
+                      "offset": 1459
                     },
                     "indent": []
                   }
@@ -3003,14 +3176,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 7,
-                      "offset": 1389
+                      "offset": 1459
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "indent": []
                   }
@@ -3020,14 +3193,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 13,
-                      "offset": 1395
+                      "offset": 1465
                     },
                     "indent": []
                   }
@@ -3037,14 +3210,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 13,
-                      "offset": 1395
+                      "offset": 1465
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 18,
-                      "offset": 1400
+                      "offset": 1470
                     },
                     "indent": []
                   }
@@ -3052,14 +3225,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 77,
+                  "line": 79,
                   "column": 5,
-                  "offset": 1387
+                  "offset": 1457
                 },
                 "end": {
-                  "line": 77,
+                  "line": 79,
                   "column": 18,
-                  "offset": 1400
+                  "offset": 1470
                 },
                 "indent": []
               }
@@ -3067,14 +3240,14 @@
           ],
           "position": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 1,
-              "offset": 1383
+              "offset": 1453
             },
             "end": {
-              "line": 77,
+              "line": 79,
               "column": 18,
-              "offset": 1400
+              "offset": 1470
             },
             "indent": []
           }
@@ -3092,292 +3265,80 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 78,
+                      "line": 80,
                       "column": 5,
-                      "offset": 1405
+                      "offset": 1475
                     },
                     "end": {
-                      "line": 78,
+                      "line": 80,
                       "column": 7,
-                      "offset": 1407
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "http",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 7,
-                      "offset": 1407
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 11,
-                      "offset": 1411
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 11,
-                      "offset": 1411
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 13,
-                      "offset": 1413
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "google.com>",
-                  "position": {
-                    "start": {
-                      "line": 78,
-                      "column": 13,
-                      "offset": 1413
-                    },
-                    "end": {
-                      "line": 78,
-                      "column": 24,
-                      "offset": 1424
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 78,
-                  "column": 5,
-                  "offset": 1405
-                },
-                "end": {
-                  "line": 78,
-                  "column": 24,
-                  "offset": 1424
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 78,
-              "column": 1,
-              "offset": 1401
-            },
-            "end": {
-              "line": 78,
-              "column": 24,
-              "offset": 1424
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 5,
-                      "offset": 1429
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 9,
-                      "offset": 1433
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "div>",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 9,
-                      "offset": 1433
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 13,
-                      "offset": 1437
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 13,
-                      "offset": 1437
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 17,
-                      "offset": 1441
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "/div>",
-                  "position": {
-                    "start": {
-                      "line": 79,
-                      "column": 17,
-                      "offset": 1441
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 22,
-                      "offset": 1446
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 79,
-                  "column": 5,
-                  "offset": 1429
-                },
-                "end": {
-                  "line": 79,
-                  "column": 22,
-                  "offset": 1446
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 79,
-              "column": 1,
-              "offset": 1425
-            },
-            "end": {
-              "line": 79,
-              "column": 22,
-              "offset": 1446
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 5,
-                      "offset": 1451
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 9,
-                      "offset": 1455
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "http",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 9,
-                      "offset": 1455
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 13,
-                      "offset": 1459
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 13,
-                      "offset": 1459
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 20,
-                      "offset": 1466
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "google.com>",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 20,
-                      "offset": 1466
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 31,
                       "offset": 1477
                     },
                     "indent": []
                   }
+                },
+                {
+                  "type": "text",
+                  "value": "http",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 7,
+                      "offset": 1477
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 11,
+                      "offset": 1481
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 11,
+                      "offset": 1481
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 13,
+                      "offset": 1483
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "google.com>",
+                  "position": {
+                    "start": {
+                      "line": 80,
+                      "column": 13,
+                      "offset": 1483
+                    },
+                    "end": {
+                      "line": 80,
+                      "column": 24,
+                      "offset": 1494
+                    },
+                    "indent": []
+                  }
                 }
               ],
               "position": {
                 "start": {
                   "line": 80,
                   "column": 5,
-                  "offset": 1451
+                  "offset": 1475
                 },
                 "end": {
                   "line": 80,
-                  "column": 31,
-                  "offset": 1477
+                  "column": 24,
+                  "offset": 1494
                 },
                 "indent": []
               }
@@ -3387,12 +3348,224 @@
             "start": {
               "line": 80,
               "column": 1,
-              "offset": 1447
+              "offset": 1471
             },
             "end": {
               "line": 80,
+              "column": 24,
+              "offset": 1494
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 5,
+                      "offset": 1499
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 9,
+                      "offset": 1503
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "div>",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 9,
+                      "offset": 1503
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 13,
+                      "offset": 1507
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 13,
+                      "offset": 1507
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 17,
+                      "offset": 1511
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "/div>",
+                  "position": {
+                    "start": {
+                      "line": 81,
+                      "column": 17,
+                      "offset": 1511
+                    },
+                    "end": {
+                      "line": 81,
+                      "column": 22,
+                      "offset": 1516
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 81,
+                  "column": 5,
+                  "offset": 1499
+                },
+                "end": {
+                  "line": 81,
+                  "column": 22,
+                  "offset": 1516
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 81,
+              "column": 1,
+              "offset": 1495
+            },
+            "end": {
+              "line": 81,
+              "column": 22,
+              "offset": 1516
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 5,
+                      "offset": 1521
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 9,
+                      "offset": 1525
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "http",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 9,
+                      "offset": 1525
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 13,
+                      "offset": 1529
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 13,
+                      "offset": 1529
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 20,
+                      "offset": 1536
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": "google.com>",
+                  "position": {
+                    "start": {
+                      "line": 82,
+                      "column": 20,
+                      "offset": 1536
+                    },
+                    "end": {
+                      "line": 82,
+                      "column": 31,
+                      "offset": 1547
+                    },
+                    "indent": []
+                  }
+                }
+              ],
+              "position": {
+                "start": {
+                  "line": 82,
+                  "column": 5,
+                  "offset": 1521
+                },
+                "end": {
+                  "line": 82,
+                  "column": 31,
+                  "offset": 1547
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 82,
+              "column": 1,
+              "offset": 1517
+            },
+            "end": {
+              "line": 82,
               "column": 31,
-              "offset": 1477
+              "offset": 1547
             },
             "indent": []
           }
@@ -3400,14 +3573,14 @@
       ],
       "position": {
         "start": {
-          "line": 77,
+          "line": 79,
           "column": 1,
-          "offset": 1383
+          "offset": 1453
         },
         "end": {
-          "line": 80,
+          "line": 82,
           "column": 31,
-          "offset": 1477
+          "offset": 1547
         },
         "indent": [
           1,
@@ -3424,9 +3597,9 @@
       "offset": 0
     },
     "end": {
-      "line": 81,
+      "line": 83,
       "column": 1,
-      "offset": 1478
+      "offset": 1548
     }
   }
 }

--- a/test/tree/stringify-escape.nogfm.json
+++ b/test/tree/stringify-escape.nogfm.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,115 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in_the_middle_of_a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +354,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +369,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +400,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 6,
-                      "offset": 194
+                      "offset": 264
                     },
                     "indent": []
                   }
@@ -348,14 +417,14 @@
                   "value": "©",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 6,
-                      "offset": 194
+                      "offset": 264
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 11,
-                      "offset": 199
+                      "offset": 269
                     },
                     "indent": []
                   }
@@ -365,14 +434,14 @@
                   "value": "cat \\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 11,
-                      "offset": 199
+                      "offset": 269
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 16,
-                      "offset": 204
+                      "offset": 274
                     },
                     "indent": []
                   }
@@ -382,14 +451,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 16,
-                      "offset": 204
+                      "offset": 274
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 21,
-                      "offset": 209
+                      "offset": 279
                     },
                     "indent": []
                   }
@@ -399,14 +468,14 @@
                   "value": " \\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 21,
-                      "offset": 209
+                      "offset": 279
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "indent": []
                   }
@@ -416,14 +485,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +515,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +540,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "indent": []
                   }
@@ -488,14 +557,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "indent": []
                   }
@@ -505,14 +574,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "indent": []
                   }
@@ -522,14 +591,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "indent": []
                   }
@@ -539,14 +608,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "indent": []
                   }
@@ -556,14 +625,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 37,
-                      "offset": 253
+                      "offset": 323
                     },
                     "indent": []
                   }
@@ -571,14 +640,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 37,
-                  "offset": 253
+                  "offset": 323
                 },
                 "indent": []
               }
@@ -586,14 +655,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 37,
-              "offset": 253
+              "offset": 323
             },
             "indent": []
           }
@@ -611,14 +680,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 5,
-                      "offset": 258
+                      "offset": 328
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "indent": []
                   }
@@ -628,14 +697,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "indent": []
                   }
@@ -645,14 +714,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 43,
-                      "offset": 296
+                      "offset": 366
                     },
                     "indent": []
                   }
@@ -660,14 +729,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 13,
+                  "line": 15,
                   "column": 5,
-                  "offset": 258
+                  "offset": 328
                 },
                 "end": {
-                  "line": 13,
+                  "line": 15,
                   "column": 43,
-                  "offset": 296
+                  "offset": 366
                 },
                 "indent": []
               }
@@ -675,14 +744,14 @@
           ],
           "position": {
             "start": {
-              "line": 13,
+              "line": 15,
               "column": 1,
-              "offset": 254
+              "offset": 324
             },
             "end": {
-              "line": 13,
+              "line": 15,
               "column": 43,
-              "offset": 296
+              "offset": 366
             },
             "indent": []
           }
@@ -690,14 +759,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 13,
+          "line": 15,
           "column": 43,
-          "offset": 296
+          "offset": 366
         },
         "indent": [
           1,
@@ -713,14 +782,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 15,
+              "line": 17,
               "column": 1,
-              "offset": 298
+              "offset": 368
             },
             "end": {
-              "line": 15,
+              "line": 17,
               "column": 63,
-              "offset": 360
+              "offset": 430
             },
             "indent": []
           }
@@ -728,14 +797,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 17,
           "column": 1,
-          "offset": 298
+          "offset": 368
         },
         "end": {
-          "line": 15,
+          "line": 17,
           "column": 63,
-          "offset": 360
+          "offset": 430
         },
         "indent": []
       }
@@ -753,14 +822,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 17,
+                  "line": 19,
                   "column": 2,
-                  "offset": 363
+                  "offset": 433
                 },
                 "end": {
-                  "line": 17,
+                  "line": 19,
                   "column": 5,
-                  "offset": 366
+                  "offset": 436
                 },
                 "indent": []
               }
@@ -768,14 +837,14 @@
           ],
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 1,
-              "offset": 362
+              "offset": 432
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "indent": []
           }
@@ -785,14 +854,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "indent": []
           }
@@ -802,14 +871,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 13,
-              "offset": 374
+              "offset": 444
             },
             "indent": []
           }
@@ -817,14 +886,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 19,
           "column": 1,
-          "offset": 362
+          "offset": 432
         },
         "end": {
-          "line": 17,
+          "line": 19,
           "column": 13,
-          "offset": 374
+          "offset": 444
         },
         "indent": []
       }
@@ -837,14 +906,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 19,
+              "line": 21,
               "column": 1,
-              "offset": 376
+              "offset": 446
             },
             "end": {
-              "line": 19,
+              "line": 21,
               "column": 53,
-              "offset": 428
+              "offset": 498
             },
             "indent": []
           }
@@ -852,14 +921,14 @@
       ],
       "position": {
         "start": {
-          "line": 19,
+          "line": 21,
           "column": 1,
-          "offset": 376
+          "offset": 446
         },
         "end": {
-          "line": 19,
+          "line": 21,
           "column": 53,
-          "offset": 428
+          "offset": 498
         },
         "indent": []
       }
@@ -872,14 +941,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 430
+              "offset": 500
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "indent": []
           }
@@ -889,14 +958,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "indent": [
               1
@@ -908,14 +977,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -925,14 +994,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "indent": [
               1
@@ -944,14 +1013,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "indent": []
           }
@@ -961,14 +1030,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 21,
-              "offset": 488
+              "offset": 558
             },
             "indent": []
           }
@@ -976,14 +1045,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 23,
           "column": 1,
-          "offset": 430
+          "offset": 500
         },
         "end": {
-          "line": 23,
+          "line": 25,
           "column": 21,
-          "offset": 488
+          "offset": 558
         },
         "indent": [
           1,
@@ -999,14 +1068,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 1,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 25,
+              "line": 27,
               "column": 25,
-              "offset": 514
+              "offset": 584
             },
             "indent": []
           }
@@ -1014,14 +1083,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 27,
           "column": 1,
-          "offset": 490
+          "offset": 560
         },
         "end": {
-          "line": 25,
+          "line": 27,
           "column": 25,
-          "offset": 514
+          "offset": 584
         },
         "indent": []
       }
@@ -1034,14 +1103,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 1,
-              "offset": 516
+              "offset": 586
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "indent": []
           }
@@ -1051,14 +1120,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 21,
-              "offset": 536
+              "offset": 606
             },
             "indent": []
           }
@@ -1066,14 +1135,14 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 29,
           "column": 1,
-          "offset": 516
+          "offset": 586
         },
         "end": {
-          "line": 27,
+          "line": 29,
           "column": 21,
-          "offset": 536
+          "offset": 606
         },
         "indent": []
       }
@@ -1086,14 +1155,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 29,
+              "line": 31,
               "column": 1,
-              "offset": 538
+              "offset": 608
             },
             "end": {
-              "line": 29,
+              "line": 31,
               "column": 16,
-              "offset": 553
+              "offset": 623
             },
             "indent": []
           }
@@ -1101,14 +1170,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 31,
           "column": 1,
-          "offset": 538
+          "offset": 608
         },
         "end": {
-          "line": 29,
+          "line": 31,
           "column": 16,
-          "offset": 553
+          "offset": 623
         },
         "indent": []
       }
@@ -1121,14 +1190,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 1,
-              "offset": 555
+              "offset": 625
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1138,14 +1207,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "indent": [
               1
@@ -1157,14 +1226,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "indent": []
           }
@@ -1174,14 +1243,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 23,
-              "offset": 594
+              "offset": 664
             },
             "indent": []
           }
@@ -1189,14 +1258,14 @@
       ],
       "position": {
         "start": {
-          "line": 31,
+          "line": 33,
           "column": 1,
-          "offset": 555
+          "offset": 625
         },
         "end": {
-          "line": 32,
+          "line": 34,
           "column": 23,
-          "offset": 594
+          "offset": 664
         },
         "indent": [
           1
@@ -1211,14 +1280,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 1,
-              "offset": 596
+              "offset": 666
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 62,
-              "offset": 657
+              "offset": 727
             },
             "indent": []
           }
@@ -1226,14 +1295,14 @@
       ],
       "position": {
         "start": {
-          "line": 34,
+          "line": 36,
           "column": 1,
-          "offset": 596
+          "offset": 666
         },
         "end": {
-          "line": 34,
+          "line": 36,
           "column": 62,
-          "offset": 657
+          "offset": 727
         },
         "indent": []
       }
@@ -1262,14 +1331,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 664
+                          "offset": 734
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 15,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1277,14 +1346,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 663
+                      "offset": 733
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 16,
-                      "offset": 674
+                      "offset": 744
                     },
                     "indent": []
                   }
@@ -1292,14 +1361,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 663
+                  "offset": 733
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 16,
-                  "offset": 674
+                  "offset": 744
                 },
                 "indent": []
               }
@@ -1307,14 +1376,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 659
+              "offset": 729
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 16,
-              "offset": 674
+              "offset": 744
             },
             "indent": []
           }
@@ -1337,14 +1406,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1354,14 +1423,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "indent": []
                       }
@@ -1371,14 +1440,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 16,
-                          "offset": 690
+                          "offset": 760
                         },
                         "indent": []
                       }
@@ -1386,14 +1455,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 679
+                      "offset": 749
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 17,
-                      "offset": 691
+                      "offset": 761
                     },
                     "indent": []
                   }
@@ -1401,14 +1470,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 679
+                  "offset": 749
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 17,
-                  "offset": 691
+                  "offset": 761
                 },
                 "indent": []
               }
@@ -1416,14 +1485,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 675
+              "offset": 745
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 17,
-              "offset": 691
+              "offset": 761
             },
             "indent": []
           }
@@ -1446,14 +1515,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 697
+                          "offset": 767
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 700
+                          "offset": 770
                         },
                         "indent": []
                       }
@@ -1461,14 +1530,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 696
+                      "offset": 766
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 10,
-                      "offset": 701
+                      "offset": 771
                     },
                     "indent": []
                   }
@@ -1476,14 +1545,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 696
+                  "offset": 766
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 10,
-                  "offset": 701
+                  "offset": 771
                 },
                 "indent": []
               }
@@ -1491,14 +1560,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 692
+              "offset": 762
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 10,
-              "offset": 701
+              "offset": 771
             },
             "indent": []
           }
@@ -1521,14 +1590,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1538,14 +1607,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1555,14 +1624,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 10,
-                          "offset": 711
+                          "offset": 781
                         },
                         "indent": []
                       }
@@ -1570,14 +1639,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 706
+                      "offset": 776
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 11,
-                      "offset": 712
+                      "offset": 782
                     },
                     "indent": []
                   }
@@ -1585,14 +1654,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 706
+                  "offset": 776
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 11,
-                  "offset": 712
+                  "offset": 782
                 },
                 "indent": []
               }
@@ -1600,14 +1669,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 11,
-              "offset": 712
+              "offset": 782
             },
             "indent": []
           }
@@ -1630,14 +1699,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 718
+                          "offset": 788
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "indent": []
                       }
@@ -1647,14 +1716,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "indent": []
                       }
@@ -1664,14 +1733,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 723
+                          "offset": 793
                         },
                         "indent": []
                       }
@@ -1679,14 +1748,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 717
+                      "offset": 787
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 12,
-                      "offset": 724
+                      "offset": 794
                     },
                     "indent": []
                   }
@@ -1694,14 +1763,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 717
+                  "offset": 787
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 12,
-                  "offset": 724
+                  "offset": 794
                 },
                 "indent": []
               }
@@ -1709,14 +1778,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 713
+              "offset": 783
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 12,
-              "offset": 724
+              "offset": 794
             },
             "indent": []
           }
@@ -1739,14 +1808,14 @@
                       "value": "a_a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 6,
-                          "offset": 730
+                          "offset": 800
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 9,
-                          "offset": 733
+                          "offset": 803
                         },
                         "indent": []
                       }
@@ -1756,14 +1825,14 @@
                       "value": "_",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 9,
-                          "offset": 733
+                          "offset": 803
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "indent": []
                       }
@@ -1773,14 +1842,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 12,
-                          "offset": 736
+                          "offset": 806
                         },
                         "indent": []
                       }
@@ -1788,14 +1857,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 41,
+                      "line": 43,
                       "column": 5,
-                      "offset": 729
+                      "offset": 799
                     },
                     "end": {
-                      "line": 41,
+                      "line": 43,
                       "column": 13,
-                      "offset": 737
+                      "offset": 807
                     },
                     "indent": []
                   }
@@ -1803,14 +1872,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
+                  "line": 43,
                   "column": 5,
-                  "offset": 729
+                  "offset": 799
                 },
                 "end": {
-                  "line": 41,
+                  "line": 43,
                   "column": 13,
-                  "offset": 737
+                  "offset": 807
                 },
                 "indent": []
               }
@@ -1818,14 +1887,14 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 43,
               "column": 1,
-              "offset": 725
+              "offset": 795
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 13,
-              "offset": 737
+              "offset": 807
             },
             "indent": []
           }
@@ -1833,14 +1902,14 @@
       ],
       "position": {
         "start": {
-          "line": 36,
+          "line": 38,
           "column": 1,
-          "offset": 659
+          "offset": 729
         },
         "end": {
-          "line": 41,
+          "line": 43,
           "column": 13,
-          "offset": 737
+          "offset": 807
         },
         "indent": [
           1,
@@ -1862,14 +1931,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 43,
+                  "line": 45,
                   "column": 3,
-                  "offset": 741
+                  "offset": 811
                 },
                 "end": {
-                  "line": 43,
+                  "line": 45,
                   "column": 7,
-                  "offset": 745
+                  "offset": 815
                 },
                 "indent": []
               }
@@ -1877,14 +1946,14 @@
           ],
           "position": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 1,
-              "offset": 739
+              "offset": 809
             },
             "end": {
-              "line": 43,
+              "line": 45,
               "column": 9,
-              "offset": 747
+              "offset": 817
             },
             "indent": []
           }
@@ -1892,14 +1961,14 @@
       ],
       "position": {
         "start": {
-          "line": 43,
+          "line": 45,
           "column": 1,
-          "offset": 739
+          "offset": 809
         },
         "end": {
-          "line": 43,
+          "line": 45,
           "column": 9,
-          "offset": 747
+          "offset": 817
         },
         "indent": []
       }
@@ -1912,14 +1981,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 45,
+              "line": 47,
               "column": 1,
-              "offset": 749
+              "offset": 819
             },
             "end": {
-              "line": 45,
+              "line": 47,
               "column": 33,
-              "offset": 781
+              "offset": 851
             },
             "indent": []
           }
@@ -1927,14 +1996,14 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 47,
           "column": 1,
-          "offset": 749
+          "offset": 819
         },
         "end": {
-          "line": 45,
+          "line": 47,
           "column": 33,
-          "offset": 781
+          "offset": 851
         },
         "indent": []
       }
@@ -1958,14 +2027,14 @@
                   "value": "http\\://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 787
+                      "offset": 857
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 842
+                      "offset": 912
                     },
                     "indent": []
                   }
@@ -1973,14 +2042,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 787
+                  "offset": 857
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 842
+                  "offset": 912
                 },
                 "indent": []
               }
@@ -1988,14 +2057,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 783
+              "offset": 853
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 842
+              "offset": 912
             },
             "indent": []
           }
@@ -2013,14 +2082,14 @@
                   "value": "https\\://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 5,
-                      "offset": 847
+                      "offset": 917
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 61,
-                      "offset": 903
+                      "offset": 973
                     },
                     "indent": []
                   }
@@ -2028,14 +2097,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 48,
+                  "line": 50,
                   "column": 5,
-                  "offset": 847
+                  "offset": 917
                 },
                 "end": {
-                  "line": 48,
+                  "line": 50,
                   "column": 61,
-                  "offset": 903
+                  "offset": 973
                 },
                 "indent": []
               }
@@ -2043,14 +2112,14 @@
           ],
           "position": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 1,
-              "offset": 843
+              "offset": 913
             },
             "end": {
-              "line": 48,
+              "line": 50,
               "column": 61,
-              "offset": 903
+              "offset": 973
             },
             "indent": []
           }
@@ -2068,14 +2137,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 5,
-                      "offset": 908
+                      "offset": 978
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "indent": []
                   }
@@ -2085,14 +2154,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "indent": []
                   }
@@ -2102,14 +2171,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 65,
-                      "offset": 968
+                      "offset": 1038
                     },
                     "indent": []
                   }
@@ -2117,14 +2186,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 51,
                   "column": 5,
-                  "offset": 908
+                  "offset": 978
                 },
                 "end": {
-                  "line": 49,
+                  "line": 51,
                   "column": 65,
-                  "offset": 968
+                  "offset": 1038
                 },
                 "indent": []
               }
@@ -2132,14 +2201,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 904
+              "offset": 974
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 65,
-              "offset": 968
+              "offset": 1038
             },
             "indent": []
           }
@@ -2157,14 +2226,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 5,
-                      "offset": 973
+                      "offset": 1043
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "indent": []
                   }
@@ -2174,14 +2243,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "indent": []
                   }
@@ -2191,14 +2260,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 66,
-                      "offset": 1034
+                      "offset": 1104
                     },
                     "indent": []
                   }
@@ -2206,14 +2275,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 50,
+                  "line": 52,
                   "column": 5,
-                  "offset": 973
+                  "offset": 1043
                 },
                 "end": {
-                  "line": 50,
+                  "line": 52,
                   "column": 66,
-                  "offset": 1034
+                  "offset": 1104
                 },
                 "indent": []
               }
@@ -2221,14 +2290,14 @@
           ],
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 1,
-              "offset": 969
+              "offset": 1039
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 66,
-              "offset": 1034
+              "offset": 1104
             },
             "indent": []
           }
@@ -2236,14 +2305,14 @@
       ],
       "position": {
         "start": {
-          "line": 47,
+          "line": 49,
           "column": 1,
-          "offset": 783
+          "offset": 853
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 66,
-          "offset": 1034
+          "offset": 1104
         },
         "indent": [
           1,
@@ -2260,14 +2329,14 @@
           "value": "Double tildes should be \\~~escaped\\~~.\nAnd here: foo~~.",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 1036
+              "offset": 1106
             },
             "end": {
-              "line": 53,
+              "line": 55,
               "column": 17,
-              "offset": 1091
+              "offset": 1161
             },
             "indent": [
               1
@@ -2277,14 +2346,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 1036
+          "offset": 1106
         },
         "end": {
-          "line": 53,
+          "line": 55,
           "column": 17,
-          "offset": 1091
+          "offset": 1161
         },
         "indent": [
           1
@@ -2299,14 +2368,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 55,
+              "line": 57,
               "column": 1,
-              "offset": 1093
+              "offset": 1163
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 36,
-              "offset": 1128
+              "offset": 1198
             },
             "indent": []
           }
@@ -2314,14 +2383,14 @@
       ],
       "position": {
         "start": {
-          "line": 55,
+          "line": 57,
           "column": 1,
-          "offset": 1093
+          "offset": 1163
         },
         "end": {
-          "line": 55,
+          "line": 57,
           "column": 36,
-          "offset": 1128
+          "offset": 1198
         },
         "indent": []
       }
@@ -2334,14 +2403,14 @@
           "value": "| here   | they     |\n| ------ | -------- |\n| should | tho\\|ugh |",
           "position": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 22,
-              "offset": 1195
+              "offset": 1265
             },
             "indent": [
               1,
@@ -2352,14 +2421,14 @@
       ],
       "position": {
         "start": {
-          "line": 57,
+          "line": 59,
           "column": 1,
-          "offset": 1130
+          "offset": 1200
         },
         "end": {
-          "line": 59,
+          "line": 61,
           "column": 22,
-          "offset": 1195
+          "offset": 1265
         },
         "indent": [
           1,
@@ -2375,14 +2444,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1197
+              "offset": 1267
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 10,
-              "offset": 1206
+              "offset": 1276
             },
             "indent": []
           }
@@ -2390,14 +2459,14 @@
       ],
       "position": {
         "start": {
-          "line": 61,
+          "line": 63,
           "column": 1,
-          "offset": 1197
+          "offset": 1267
         },
         "end": {
-          "line": 61,
+          "line": 63,
           "column": 10,
-          "offset": 1206
+          "offset": 1276
         },
         "indent": []
       }
@@ -2410,14 +2479,14 @@
           "value": "| here   | they   |\n\\| ---- \\| ----- \\|\n| should | though |",
           "position": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 1,
-              "offset": 1208
+              "offset": 1278
             },
             "end": {
-              "line": 65,
+              "line": 67,
               "column": 20,
-              "offset": 1267
+              "offset": 1337
             },
             "indent": [
               1,
@@ -2428,14 +2497,14 @@
       ],
       "position": {
         "start": {
-          "line": 63,
+          "line": 65,
           "column": 1,
-          "offset": 1208
+          "offset": 1278
         },
         "end": {
-          "line": 65,
+          "line": 67,
           "column": 20,
-          "offset": 1267
+          "offset": 1337
         },
         "indent": [
           1,
@@ -2451,14 +2520,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1269
+              "offset": 1339
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 10,
-              "offset": 1278
+              "offset": 1348
             },
             "indent": []
           }
@@ -2466,14 +2535,14 @@
       ],
       "position": {
         "start": {
-          "line": 67,
+          "line": 69,
           "column": 1,
-          "offset": 1269
+          "offset": 1339
         },
         "end": {
-          "line": 67,
+          "line": 69,
           "column": 10,
-          "offset": 1278
+          "offset": 1348
         },
         "indent": []
       }
@@ -2486,14 +2555,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 69,
+              "line": 71,
               "column": 1,
-              "offset": 1280
+              "offset": 1350
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "indent": [
               1
@@ -2505,14 +2574,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "indent": []
           }
@@ -2522,14 +2591,14 @@
           "value": "--- \\| ------\nshould | though",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "end": {
-              "line": 71,
+              "line": 73,
               "column": 16,
-              "offset": 1325
+              "offset": 1395
             },
             "indent": [
               1
@@ -2539,14 +2608,14 @@
       ],
       "position": {
         "start": {
-          "line": 69,
+          "line": 71,
           "column": 1,
-          "offset": 1280
+          "offset": 1350
         },
         "end": {
-          "line": 71,
+          "line": 73,
           "column": 16,
-          "offset": 1325
+          "offset": 1395
         },
         "indent": [
           1,
@@ -2565,14 +2634,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 73,
+                  "line": 75,
                   "column": 3,
-                  "offset": 1329
+                  "offset": 1399
                 },
                 "end": {
-                  "line": 73,
+                  "line": 75,
                   "column": 14,
-                  "offset": 1340
+                  "offset": 1410
                 },
                 "indent": []
               }
@@ -2580,14 +2649,14 @@
           ],
           "position": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 1,
-              "offset": 1327
+              "offset": 1397
             },
             "end": {
-              "line": 73,
+              "line": 75,
               "column": 16,
-              "offset": 1342
+              "offset": 1412
             },
             "indent": []
           }
@@ -2595,14 +2664,14 @@
       ],
       "position": {
         "start": {
-          "line": 73,
+          "line": 75,
           "column": 1,
-          "offset": 1327
+          "offset": 1397
         },
         "end": {
-          "line": 73,
+          "line": 75,
           "column": 16,
-          "offset": 1342
+          "offset": 1412
         },
         "indent": []
       }
@@ -2615,14 +2684,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1344
+              "offset": 1414
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 38,
-              "offset": 1381
+              "offset": 1451
             },
             "indent": []
           }
@@ -2630,14 +2699,14 @@
       ],
       "position": {
         "start": {
-          "line": 75,
+          "line": 77,
           "column": 1,
-          "offset": 1344
+          "offset": 1414
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 38,
-          "offset": 1381
+          "offset": 1451
         },
         "indent": []
       }
@@ -2661,14 +2730,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 5,
-                      "offset": 1387
+                      "offset": 1457
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 6,
-                      "offset": 1388
+                      "offset": 1458
                     },
                     "indent": []
                   }
@@ -2678,14 +2747,14 @@
                   "value": "<div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 6,
-                      "offset": 1388
+                      "offset": 1458
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "indent": []
                   }
@@ -2695,14 +2764,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 12,
-                      "offset": 1394
+                      "offset": 1464
                     },
                     "indent": []
                   }
@@ -2712,14 +2781,14 @@
                   "value": "</div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 12,
-                      "offset": 1394
+                      "offset": 1464
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 18,
-                      "offset": 1400
+                      "offset": 1470
                     },
                     "indent": []
                   }
@@ -2727,14 +2796,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 77,
+                  "line": 79,
                   "column": 5,
-                  "offset": 1387
+                  "offset": 1457
                 },
                 "end": {
-                  "line": 77,
+                  "line": 79,
                   "column": 18,
-                  "offset": 1400
+                  "offset": 1470
                 },
                 "indent": []
               }
@@ -2742,14 +2811,14 @@
           ],
           "position": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 1,
-              "offset": 1383
+              "offset": 1453
             },
             "end": {
-              "line": 77,
+              "line": 79,
               "column": 18,
-              "offset": 1400
+              "offset": 1470
             },
             "indent": []
           }
@@ -2767,14 +2836,14 @@
                   "value": "\\<http\\:google.com>",
                   "position": {
                     "start": {
-                      "line": 78,
+                      "line": 80,
                       "column": 5,
-                      "offset": 1405
+                      "offset": 1475
                     },
                     "end": {
-                      "line": 78,
+                      "line": 80,
                       "column": 24,
-                      "offset": 1424
+                      "offset": 1494
                     },
                     "indent": []
                   }
@@ -2782,14 +2851,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 78,
+                  "line": 80,
                   "column": 5,
-                  "offset": 1405
+                  "offset": 1475
                 },
                 "end": {
-                  "line": 78,
+                  "line": 80,
                   "column": 24,
-                  "offset": 1424
+                  "offset": 1494
                 },
                 "indent": []
               }
@@ -2797,14 +2866,14 @@
           ],
           "position": {
             "start": {
-              "line": 78,
+              "line": 80,
               "column": 1,
-              "offset": 1401
+              "offset": 1471
             },
             "end": {
-              "line": 78,
+              "line": 80,
               "column": 24,
-              "offset": 1424
+              "offset": 1494
             },
             "indent": []
           }
@@ -2822,14 +2891,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 5,
-                      "offset": 1429
+                      "offset": 1499
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 9,
-                      "offset": 1433
+                      "offset": 1503
                     },
                     "indent": []
                   }
@@ -2839,14 +2908,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 9,
-                      "offset": 1433
+                      "offset": 1503
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 13,
-                      "offset": 1437
+                      "offset": 1507
                     },
                     "indent": []
                   }
@@ -2856,14 +2925,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 13,
-                      "offset": 1437
+                      "offset": 1507
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 17,
-                      "offset": 1441
+                      "offset": 1511
                     },
                     "indent": []
                   }
@@ -2873,14 +2942,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 17,
-                      "offset": 1441
+                      "offset": 1511
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 22,
-                      "offset": 1446
+                      "offset": 1516
                     },
                     "indent": []
                   }
@@ -2888,14 +2957,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 79,
+                  "line": 81,
                   "column": 5,
-                  "offset": 1429
+                  "offset": 1499
                 },
                 "end": {
-                  "line": 79,
+                  "line": 81,
                   "column": 22,
-                  "offset": 1446
+                  "offset": 1516
                 },
                 "indent": []
               }
@@ -2903,14 +2972,14 @@
           ],
           "position": {
             "start": {
-              "line": 79,
+              "line": 81,
               "column": 1,
-              "offset": 1425
+              "offset": 1495
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 22,
-              "offset": 1446
+              "offset": 1516
             },
             "indent": []
           }
@@ -2928,14 +2997,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 5,
-                      "offset": 1451
+                      "offset": 1521
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 9,
-                      "offset": 1455
+                      "offset": 1525
                     },
                     "indent": []
                   }
@@ -2945,14 +3014,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 9,
-                      "offset": 1455
+                      "offset": 1525
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 13,
-                      "offset": 1459
+                      "offset": 1529
                     },
                     "indent": []
                   }
@@ -2962,14 +3031,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 13,
-                      "offset": 1459
+                      "offset": 1529
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 20,
-                      "offset": 1466
+                      "offset": 1536
                     },
                     "indent": []
                   }
@@ -2979,14 +3048,14 @@
                   "value": "google.com>",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 20,
-                      "offset": 1466
+                      "offset": 1536
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 31,
-                      "offset": 1477
+                      "offset": 1547
                     },
                     "indent": []
                   }
@@ -2994,14 +3063,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 80,
+                  "line": 82,
                   "column": 5,
-                  "offset": 1451
+                  "offset": 1521
                 },
                 "end": {
-                  "line": 80,
+                  "line": 82,
                   "column": 31,
-                  "offset": 1477
+                  "offset": 1547
                 },
                 "indent": []
               }
@@ -3009,14 +3078,14 @@
           ],
           "position": {
             "start": {
-              "line": 80,
+              "line": 82,
               "column": 1,
-              "offset": 1447
+              "offset": 1517
             },
             "end": {
-              "line": 80,
+              "line": 82,
               "column": 31,
-              "offset": 1477
+              "offset": 1547
             },
             "indent": []
           }
@@ -3024,14 +3093,14 @@
       ],
       "position": {
         "start": {
-          "line": 77,
+          "line": 79,
           "column": 1,
-          "offset": 1383
+          "offset": 1453
         },
         "end": {
-          "line": 80,
+          "line": 82,
           "column": 31,
-          "offset": 1477
+          "offset": 1547
         },
         "indent": [
           1,
@@ -3048,9 +3117,9 @@
       "offset": 0
     },
     "end": {
-      "line": 81,
+      "line": 83,
       "column": 1,
-      "offset": 1478
+      "offset": 1548
     }
   }
 }

--- a/test/tree/stringify-escape.nogfm.pedantic.json
+++ b/test/tree/stringify-escape.nogfm.pedantic.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,219 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 50,
+              "offset": 163
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "emphasis",
+          "children": [
+            {
+              "type": "text",
+              "value": "the",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 51,
+                  "offset": 164
+                },
+                "end": {
+                  "line": 9,
+                  "column": 54,
+                  "offset": 167
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 50,
+              "offset": 163
+            },
+            "end": {
+              "line": 9,
+              "column": 55,
+              "offset": 168
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "middle",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 55,
+              "offset": 168
+            },
+            "end": {
+              "line": 9,
+              "column": 61,
+              "offset": 174
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "emphasis",
+          "children": [
+            {
+              "type": "text",
+              "value": "of",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 62,
+                  "offset": 175
+                },
+                "end": {
+                  "line": 9,
+                  "column": 64,
+                  "offset": 177
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 61,
+              "offset": 174
+            },
+            "end": {
+              "line": 9,
+              "column": 65,
+              "offset": 178
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 65,
+              "offset": 178
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +458,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +473,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +504,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 6,
-                      "offset": 194
+                      "offset": 264
                     },
                     "indent": []
                   }
@@ -348,14 +521,14 @@
                   "value": "©",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 6,
-                      "offset": 194
+                      "offset": 264
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 11,
-                      "offset": 199
+                      "offset": 269
                     },
                     "indent": []
                   }
@@ -365,14 +538,14 @@
                   "value": "cat \\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 11,
-                      "offset": 199
+                      "offset": 269
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 16,
-                      "offset": 204
+                      "offset": 274
                     },
                     "indent": []
                   }
@@ -382,14 +555,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 16,
-                      "offset": 204
+                      "offset": 274
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 21,
-                      "offset": 209
+                      "offset": 279
                     },
                     "indent": []
                   }
@@ -399,14 +572,14 @@
                   "value": " \\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 21,
-                      "offset": 209
+                      "offset": 279
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "indent": []
                   }
@@ -416,14 +589,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +604,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +619,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +644,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "indent": []
                   }
@@ -488,14 +661,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "indent": []
                   }
@@ -505,14 +678,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "indent": []
                   }
@@ -522,14 +695,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "indent": []
                   }
@@ -539,14 +712,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "indent": []
                   }
@@ -556,14 +729,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 37,
-                      "offset": 253
+                      "offset": 323
                     },
                     "indent": []
                   }
@@ -571,14 +744,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 37,
-                  "offset": 253
+                  "offset": 323
                 },
                 "indent": []
               }
@@ -586,14 +759,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 37,
-              "offset": 253
+              "offset": 323
             },
             "indent": []
           }
@@ -611,14 +784,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 5,
-                      "offset": 258
+                      "offset": 328
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "indent": []
                   }
@@ -628,14 +801,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "indent": []
                   }
@@ -645,14 +818,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 43,
-                      "offset": 296
+                      "offset": 366
                     },
                     "indent": []
                   }
@@ -660,14 +833,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 13,
+                  "line": 15,
                   "column": 5,
-                  "offset": 258
+                  "offset": 328
                 },
                 "end": {
-                  "line": 13,
+                  "line": 15,
                   "column": 43,
-                  "offset": 296
+                  "offset": 366
                 },
                 "indent": []
               }
@@ -675,14 +848,14 @@
           ],
           "position": {
             "start": {
-              "line": 13,
+              "line": 15,
               "column": 1,
-              "offset": 254
+              "offset": 324
             },
             "end": {
-              "line": 13,
+              "line": 15,
               "column": 43,
-              "offset": 296
+              "offset": 366
             },
             "indent": []
           }
@@ -690,14 +863,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 13,
+          "line": 15,
           "column": 43,
-          "offset": 296
+          "offset": 366
         },
         "indent": [
           1,
@@ -713,14 +886,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 15,
+              "line": 17,
               "column": 1,
-              "offset": 298
+              "offset": 368
             },
             "end": {
-              "line": 15,
+              "line": 17,
               "column": 63,
-              "offset": 360
+              "offset": 430
             },
             "indent": []
           }
@@ -728,14 +901,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 17,
           "column": 1,
-          "offset": 298
+          "offset": 368
         },
         "end": {
-          "line": 15,
+          "line": 17,
           "column": 63,
-          "offset": 360
+          "offset": 430
         },
         "indent": []
       }
@@ -753,14 +926,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 17,
+                  "line": 19,
                   "column": 2,
-                  "offset": 363
+                  "offset": 433
                 },
                 "end": {
-                  "line": 17,
+                  "line": 19,
                   "column": 5,
-                  "offset": 366
+                  "offset": 436
                 },
                 "indent": []
               }
@@ -768,14 +941,14 @@
           ],
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 1,
-              "offset": 362
+              "offset": 432
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "indent": []
           }
@@ -785,14 +958,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "indent": []
           }
@@ -802,14 +975,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 13,
-              "offset": 374
+              "offset": 444
             },
             "indent": []
           }
@@ -817,14 +990,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 19,
           "column": 1,
-          "offset": 362
+          "offset": 432
         },
         "end": {
-          "line": 17,
+          "line": 19,
           "column": 13,
-          "offset": 374
+          "offset": 444
         },
         "indent": []
       }
@@ -837,14 +1010,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 19,
+              "line": 21,
               "column": 1,
-              "offset": 376
+              "offset": 446
             },
             "end": {
-              "line": 19,
+              "line": 21,
               "column": 53,
-              "offset": 428
+              "offset": 498
             },
             "indent": []
           }
@@ -852,14 +1025,14 @@
       ],
       "position": {
         "start": {
-          "line": 19,
+          "line": 21,
           "column": 1,
-          "offset": 376
+          "offset": 446
         },
         "end": {
-          "line": 19,
+          "line": 21,
           "column": 53,
-          "offset": 428
+          "offset": 498
         },
         "indent": []
       }
@@ -872,14 +1045,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 430
+              "offset": 500
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "indent": []
           }
@@ -889,14 +1062,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "indent": [
               1
@@ -908,14 +1081,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -925,14 +1098,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "indent": [
               1
@@ -944,14 +1117,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "indent": []
           }
@@ -961,14 +1134,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 21,
-              "offset": 488
+              "offset": 558
             },
             "indent": []
           }
@@ -976,14 +1149,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 23,
           "column": 1,
-          "offset": 430
+          "offset": 500
         },
         "end": {
-          "line": 23,
+          "line": 25,
           "column": 21,
-          "offset": 488
+          "offset": 558
         },
         "indent": [
           1,
@@ -999,14 +1172,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 1,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 25,
+              "line": 27,
               "column": 25,
-              "offset": 514
+              "offset": 584
             },
             "indent": []
           }
@@ -1014,14 +1187,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 27,
           "column": 1,
-          "offset": 490
+          "offset": 560
         },
         "end": {
-          "line": 25,
+          "line": 27,
           "column": 25,
-          "offset": 514
+          "offset": 584
         },
         "indent": []
       }
@@ -1034,14 +1207,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 1,
-              "offset": 516
+              "offset": 586
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "indent": []
           }
@@ -1051,14 +1224,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 21,
-              "offset": 536
+              "offset": 606
             },
             "indent": []
           }
@@ -1066,14 +1239,14 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 29,
           "column": 1,
-          "offset": 516
+          "offset": 586
         },
         "end": {
-          "line": 27,
+          "line": 29,
           "column": 21,
-          "offset": 536
+          "offset": 606
         },
         "indent": []
       }
@@ -1086,14 +1259,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 29,
+              "line": 31,
               "column": 1,
-              "offset": 538
+              "offset": 608
             },
             "end": {
-              "line": 29,
+              "line": 31,
               "column": 16,
-              "offset": 553
+              "offset": 623
             },
             "indent": []
           }
@@ -1101,14 +1274,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 31,
           "column": 1,
-          "offset": 538
+          "offset": 608
         },
         "end": {
-          "line": 29,
+          "line": 31,
           "column": 16,
-          "offset": 553
+          "offset": 623
         },
         "indent": []
       }
@@ -1121,14 +1294,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 1,
-              "offset": 555
+              "offset": 625
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1138,14 +1311,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "indent": [
               1
@@ -1157,14 +1330,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "indent": []
           }
@@ -1174,14 +1347,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 23,
-              "offset": 594
+              "offset": 664
             },
             "indent": []
           }
@@ -1189,14 +1362,14 @@
       ],
       "position": {
         "start": {
-          "line": 31,
+          "line": 33,
           "column": 1,
-          "offset": 555
+          "offset": 625
         },
         "end": {
-          "line": 32,
+          "line": 34,
           "column": 23,
-          "offset": 594
+          "offset": 664
         },
         "indent": [
           1
@@ -1211,14 +1384,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 1,
-              "offset": 596
+              "offset": 666
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 62,
-              "offset": 657
+              "offset": 727
             },
             "indent": []
           }
@@ -1226,14 +1399,14 @@
       ],
       "position": {
         "start": {
-          "line": 34,
+          "line": 36,
           "column": 1,
-          "offset": 596
+          "offset": 666
         },
         "end": {
-          "line": 34,
+          "line": 36,
           "column": 62,
-          "offset": 657
+          "offset": 727
         },
         "indent": []
       }
@@ -1262,14 +1435,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 664
+                          "offset": 734
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 15,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1277,14 +1450,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 663
+                      "offset": 733
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 16,
-                      "offset": 674
+                      "offset": 744
                     },
                     "indent": []
                   }
@@ -1292,14 +1465,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 663
+                  "offset": 733
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 16,
-                  "offset": 674
+                  "offset": 744
                 },
                 "indent": []
               }
@@ -1307,14 +1480,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 659
+              "offset": 729
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 16,
-              "offset": 674
+              "offset": 744
             },
             "indent": []
           }
@@ -1337,14 +1510,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1354,14 +1527,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "indent": []
                       }
@@ -1371,14 +1544,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 16,
-                          "offset": 690
+                          "offset": 760
                         },
                         "indent": []
                       }
@@ -1386,14 +1559,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 679
+                      "offset": 749
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 17,
-                      "offset": 691
+                      "offset": 761
                     },
                     "indent": []
                   }
@@ -1401,14 +1574,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 679
+                  "offset": 749
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 17,
-                  "offset": 691
+                  "offset": 761
                 },
                 "indent": []
               }
@@ -1416,14 +1589,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 675
+              "offset": 745
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 17,
-              "offset": 691
+              "offset": 761
             },
             "indent": []
           }
@@ -1446,14 +1619,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 697
+                          "offset": 767
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 700
+                          "offset": 770
                         },
                         "indent": []
                       }
@@ -1461,14 +1634,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 696
+                      "offset": 766
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 10,
-                      "offset": 701
+                      "offset": 771
                     },
                     "indent": []
                   }
@@ -1476,14 +1649,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 696
+                  "offset": 766
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 10,
-                  "offset": 701
+                  "offset": 771
                 },
                 "indent": []
               }
@@ -1491,14 +1664,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 692
+              "offset": 762
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 10,
-              "offset": 701
+              "offset": 771
             },
             "indent": []
           }
@@ -1521,14 +1694,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1538,14 +1711,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1555,14 +1728,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 10,
-                          "offset": 711
+                          "offset": 781
                         },
                         "indent": []
                       }
@@ -1570,14 +1743,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 706
+                      "offset": 776
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 11,
-                      "offset": 712
+                      "offset": 782
                     },
                     "indent": []
                   }
@@ -1585,14 +1758,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 706
+                  "offset": 776
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 11,
-                  "offset": 712
+                  "offset": 782
                 },
                 "indent": []
               }
@@ -1600,14 +1773,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 11,
-              "offset": 712
+              "offset": 782
             },
             "indent": []
           }
@@ -1630,14 +1803,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 718
+                          "offset": 788
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "indent": []
                       }
@@ -1647,14 +1820,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "indent": []
                       }
@@ -1664,14 +1837,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 723
+                          "offset": 793
                         },
                         "indent": []
                       }
@@ -1679,14 +1852,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 717
+                      "offset": 787
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 12,
-                      "offset": 724
+                      "offset": 794
                     },
                     "indent": []
                   }
@@ -1694,14 +1867,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 717
+                  "offset": 787
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 12,
-                  "offset": 724
+                  "offset": 794
                 },
                 "indent": []
               }
@@ -1709,14 +1882,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 713
+              "offset": 783
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 12,
-              "offset": 724
+              "offset": 794
             },
             "indent": []
           }
@@ -1739,14 +1912,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 6,
-                          "offset": 730
+                          "offset": 800
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 7,
-                          "offset": 731
+                          "offset": 801
                         },
                         "indent": []
                       }
@@ -1759,14 +1932,14 @@
                           "value": "a\\",
                           "position": {
                             "start": {
-                              "line": 41,
+                              "line": 43,
                               "column": 8,
-                              "offset": 732
+                              "offset": 802
                             },
                             "end": {
-                              "line": 41,
+                              "line": 43,
                               "column": 10,
-                              "offset": 734
+                              "offset": 804
                             },
                             "indent": []
                           }
@@ -1774,14 +1947,14 @@
                       ],
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 7,
-                          "offset": 731
+                          "offset": 801
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "indent": []
                       }
@@ -1791,14 +1964,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 12,
-                          "offset": 736
+                          "offset": 806
                         },
                         "indent": []
                       }
@@ -1806,14 +1979,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 41,
+                      "line": 43,
                       "column": 5,
-                      "offset": 729
+                      "offset": 799
                     },
                     "end": {
-                      "line": 41,
+                      "line": 43,
                       "column": 13,
-                      "offset": 737
+                      "offset": 807
                     },
                     "indent": []
                   }
@@ -1821,14 +1994,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
+                  "line": 43,
                   "column": 5,
-                  "offset": 729
+                  "offset": 799
                 },
                 "end": {
-                  "line": 41,
+                  "line": 43,
                   "column": 13,
-                  "offset": 737
+                  "offset": 807
                 },
                 "indent": []
               }
@@ -1836,14 +2009,14 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 43,
               "column": 1,
-              "offset": 725
+              "offset": 795
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 13,
-              "offset": 737
+              "offset": 807
             },
             "indent": []
           }
@@ -1851,14 +2024,14 @@
       ],
       "position": {
         "start": {
-          "line": 36,
+          "line": 38,
           "column": 1,
-          "offset": 659
+          "offset": 729
         },
         "end": {
-          "line": 41,
+          "line": 43,
           "column": 13,
-          "offset": 737
+          "offset": 807
         },
         "indent": [
           1,
@@ -1880,14 +2053,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 43,
+                  "line": 45,
                   "column": 3,
-                  "offset": 741
+                  "offset": 811
                 },
                 "end": {
-                  "line": 43,
+                  "line": 45,
                   "column": 7,
-                  "offset": 745
+                  "offset": 815
                 },
                 "indent": []
               }
@@ -1895,14 +2068,14 @@
           ],
           "position": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 1,
-              "offset": 739
+              "offset": 809
             },
             "end": {
-              "line": 43,
+              "line": 45,
               "column": 9,
-              "offset": 747
+              "offset": 817
             },
             "indent": []
           }
@@ -1910,14 +2083,14 @@
       ],
       "position": {
         "start": {
-          "line": 43,
+          "line": 45,
           "column": 1,
-          "offset": 739
+          "offset": 809
         },
         "end": {
-          "line": 43,
+          "line": 45,
           "column": 9,
-          "offset": 747
+          "offset": 817
         },
         "indent": []
       }
@@ -1930,14 +2103,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 45,
+              "line": 47,
               "column": 1,
-              "offset": 749
+              "offset": 819
             },
             "end": {
-              "line": 45,
+              "line": 47,
               "column": 33,
-              "offset": 781
+              "offset": 851
             },
             "indent": []
           }
@@ -1945,14 +2118,14 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 47,
           "column": 1,
-          "offset": 749
+          "offset": 819
         },
         "end": {
-          "line": 45,
+          "line": 47,
           "column": 33,
-          "offset": 781
+          "offset": 851
         },
         "indent": []
       }
@@ -1976,14 +2149,14 @@
                   "value": "http\\://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 787
+                      "offset": 857
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 842
+                      "offset": 912
                     },
                     "indent": []
                   }
@@ -1991,14 +2164,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 787
+                  "offset": 857
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 842
+                  "offset": 912
                 },
                 "indent": []
               }
@@ -2006,14 +2179,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 783
+              "offset": 853
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 842
+              "offset": 912
             },
             "indent": []
           }
@@ -2031,14 +2204,14 @@
                   "value": "https\\://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 5,
-                      "offset": 847
+                      "offset": 917
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 61,
-                      "offset": 903
+                      "offset": 973
                     },
                     "indent": []
                   }
@@ -2046,14 +2219,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 48,
+                  "line": 50,
                   "column": 5,
-                  "offset": 847
+                  "offset": 917
                 },
                 "end": {
-                  "line": 48,
+                  "line": 50,
                   "column": 61,
-                  "offset": 903
+                  "offset": 973
                 },
                 "indent": []
               }
@@ -2061,14 +2234,14 @@
           ],
           "position": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 1,
-              "offset": 843
+              "offset": 913
             },
             "end": {
-              "line": 48,
+              "line": 50,
               "column": 61,
-              "offset": 903
+              "offset": 973
             },
             "indent": []
           }
@@ -2086,14 +2259,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 5,
-                      "offset": 908
+                      "offset": 978
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "indent": []
                   }
@@ -2103,14 +2276,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "indent": []
                   }
@@ -2120,14 +2293,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 65,
-                      "offset": 968
+                      "offset": 1038
                     },
                     "indent": []
                   }
@@ -2135,14 +2308,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 51,
                   "column": 5,
-                  "offset": 908
+                  "offset": 978
                 },
                 "end": {
-                  "line": 49,
+                  "line": 51,
                   "column": 65,
-                  "offset": 968
+                  "offset": 1038
                 },
                 "indent": []
               }
@@ -2150,14 +2323,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 904
+              "offset": 974
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 65,
-              "offset": 968
+              "offset": 1038
             },
             "indent": []
           }
@@ -2175,14 +2348,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 5,
-                      "offset": 973
+                      "offset": 1043
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "indent": []
                   }
@@ -2192,14 +2365,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "indent": []
                   }
@@ -2209,14 +2382,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 66,
-                      "offset": 1034
+                      "offset": 1104
                     },
                     "indent": []
                   }
@@ -2224,14 +2397,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 50,
+                  "line": 52,
                   "column": 5,
-                  "offset": 973
+                  "offset": 1043
                 },
                 "end": {
-                  "line": 50,
+                  "line": 52,
                   "column": 66,
-                  "offset": 1034
+                  "offset": 1104
                 },
                 "indent": []
               }
@@ -2239,14 +2412,14 @@
           ],
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 1,
-              "offset": 969
+              "offset": 1039
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 66,
-              "offset": 1034
+              "offset": 1104
             },
             "indent": []
           }
@@ -2254,14 +2427,14 @@
       ],
       "position": {
         "start": {
-          "line": 47,
+          "line": 49,
           "column": 1,
-          "offset": 783
+          "offset": 853
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 66,
-          "offset": 1034
+          "offset": 1104
         },
         "indent": [
           1,
@@ -2278,14 +2451,14 @@
           "value": "Double tildes should be \\~~escaped\\~~.\nAnd here: foo~~.",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 1036
+              "offset": 1106
             },
             "end": {
-              "line": 53,
+              "line": 55,
               "column": 17,
-              "offset": 1091
+              "offset": 1161
             },
             "indent": [
               1
@@ -2295,14 +2468,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 1036
+          "offset": 1106
         },
         "end": {
-          "line": 53,
+          "line": 55,
           "column": 17,
-          "offset": 1091
+          "offset": 1161
         },
         "indent": [
           1
@@ -2317,14 +2490,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 55,
+              "line": 57,
               "column": 1,
-              "offset": 1093
+              "offset": 1163
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 36,
-              "offset": 1128
+              "offset": 1198
             },
             "indent": []
           }
@@ -2332,14 +2505,14 @@
       ],
       "position": {
         "start": {
-          "line": 55,
+          "line": 57,
           "column": 1,
-          "offset": 1093
+          "offset": 1163
         },
         "end": {
-          "line": 55,
+          "line": 57,
           "column": 36,
-          "offset": 1128
+          "offset": 1198
         },
         "indent": []
       }
@@ -2352,14 +2525,14 @@
           "value": "| here   | they     |\n| ------ | -------- |\n| should | tho\\|ugh |",
           "position": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 22,
-              "offset": 1195
+              "offset": 1265
             },
             "indent": [
               1,
@@ -2370,14 +2543,14 @@
       ],
       "position": {
         "start": {
-          "line": 57,
+          "line": 59,
           "column": 1,
-          "offset": 1130
+          "offset": 1200
         },
         "end": {
-          "line": 59,
+          "line": 61,
           "column": 22,
-          "offset": 1195
+          "offset": 1265
         },
         "indent": [
           1,
@@ -2393,14 +2566,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1197
+              "offset": 1267
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 10,
-              "offset": 1206
+              "offset": 1276
             },
             "indent": []
           }
@@ -2408,14 +2581,14 @@
       ],
       "position": {
         "start": {
-          "line": 61,
+          "line": 63,
           "column": 1,
-          "offset": 1197
+          "offset": 1267
         },
         "end": {
-          "line": 61,
+          "line": 63,
           "column": 10,
-          "offset": 1206
+          "offset": 1276
         },
         "indent": []
       }
@@ -2428,14 +2601,14 @@
           "value": "| here   | they   |\n\\| ---- \\| ----- \\|\n| should | though |",
           "position": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 1,
-              "offset": 1208
+              "offset": 1278
             },
             "end": {
-              "line": 65,
+              "line": 67,
               "column": 20,
-              "offset": 1267
+              "offset": 1337
             },
             "indent": [
               1,
@@ -2446,14 +2619,14 @@
       ],
       "position": {
         "start": {
-          "line": 63,
+          "line": 65,
           "column": 1,
-          "offset": 1208
+          "offset": 1278
         },
         "end": {
-          "line": 65,
+          "line": 67,
           "column": 20,
-          "offset": 1267
+          "offset": 1337
         },
         "indent": [
           1,
@@ -2469,14 +2642,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1269
+              "offset": 1339
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 10,
-              "offset": 1278
+              "offset": 1348
             },
             "indent": []
           }
@@ -2484,14 +2657,14 @@
       ],
       "position": {
         "start": {
-          "line": 67,
+          "line": 69,
           "column": 1,
-          "offset": 1269
+          "offset": 1339
         },
         "end": {
-          "line": 67,
+          "line": 69,
           "column": 10,
-          "offset": 1278
+          "offset": 1348
         },
         "indent": []
       }
@@ -2504,14 +2677,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 69,
+              "line": 71,
               "column": 1,
-              "offset": 1280
+              "offset": 1350
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "indent": [
               1
@@ -2523,14 +2696,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "indent": []
           }
@@ -2540,14 +2713,14 @@
           "value": "--- \\| ------\nshould | though",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "end": {
-              "line": 71,
+              "line": 73,
               "column": 16,
-              "offset": 1325
+              "offset": 1395
             },
             "indent": [
               1
@@ -2557,14 +2730,14 @@
       ],
       "position": {
         "start": {
-          "line": 69,
+          "line": 71,
           "column": 1,
-          "offset": 1280
+          "offset": 1350
         },
         "end": {
-          "line": 71,
+          "line": 73,
           "column": 16,
-          "offset": 1325
+          "offset": 1395
         },
         "indent": [
           1,
@@ -2583,14 +2756,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 73,
+                  "line": 75,
                   "column": 3,
-                  "offset": 1329
+                  "offset": 1399
                 },
                 "end": {
-                  "line": 73,
+                  "line": 75,
                   "column": 14,
-                  "offset": 1340
+                  "offset": 1410
                 },
                 "indent": []
               }
@@ -2598,14 +2771,14 @@
           ],
           "position": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 1,
-              "offset": 1327
+              "offset": 1397
             },
             "end": {
-              "line": 73,
+              "line": 75,
               "column": 16,
-              "offset": 1342
+              "offset": 1412
             },
             "indent": []
           }
@@ -2613,14 +2786,14 @@
       ],
       "position": {
         "start": {
-          "line": 73,
+          "line": 75,
           "column": 1,
-          "offset": 1327
+          "offset": 1397
         },
         "end": {
-          "line": 73,
+          "line": 75,
           "column": 16,
-          "offset": 1342
+          "offset": 1412
         },
         "indent": []
       }
@@ -2633,14 +2806,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1344
+              "offset": 1414
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 38,
-              "offset": 1381
+              "offset": 1451
             },
             "indent": []
           }
@@ -2648,14 +2821,14 @@
       ],
       "position": {
         "start": {
-          "line": 75,
+          "line": 77,
           "column": 1,
-          "offset": 1344
+          "offset": 1414
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 38,
-          "offset": 1381
+          "offset": 1451
         },
         "indent": []
       }
@@ -2679,14 +2852,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 5,
-                      "offset": 1387
+                      "offset": 1457
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 6,
-                      "offset": 1388
+                      "offset": 1458
                     },
                     "indent": []
                   }
@@ -2696,14 +2869,14 @@
                   "value": "<div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 6,
-                      "offset": 1388
+                      "offset": 1458
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "indent": []
                   }
@@ -2713,14 +2886,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 12,
-                      "offset": 1394
+                      "offset": 1464
                     },
                     "indent": []
                   }
@@ -2730,14 +2903,14 @@
                   "value": "</div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 12,
-                      "offset": 1394
+                      "offset": 1464
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 18,
-                      "offset": 1400
+                      "offset": 1470
                     },
                     "indent": []
                   }
@@ -2745,14 +2918,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 77,
+                  "line": 79,
                   "column": 5,
-                  "offset": 1387
+                  "offset": 1457
                 },
                 "end": {
-                  "line": 77,
+                  "line": 79,
                   "column": 18,
-                  "offset": 1400
+                  "offset": 1470
                 },
                 "indent": []
               }
@@ -2760,14 +2933,14 @@
           ],
           "position": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 1,
-              "offset": 1383
+              "offset": 1453
             },
             "end": {
-              "line": 77,
+              "line": 79,
               "column": 18,
-              "offset": 1400
+              "offset": 1470
             },
             "indent": []
           }
@@ -2785,14 +2958,14 @@
                   "value": "\\<http\\:google.com>",
                   "position": {
                     "start": {
-                      "line": 78,
+                      "line": 80,
                       "column": 5,
-                      "offset": 1405
+                      "offset": 1475
                     },
                     "end": {
-                      "line": 78,
+                      "line": 80,
                       "column": 24,
-                      "offset": 1424
+                      "offset": 1494
                     },
                     "indent": []
                   }
@@ -2800,14 +2973,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 78,
+                  "line": 80,
                   "column": 5,
-                  "offset": 1405
+                  "offset": 1475
                 },
                 "end": {
-                  "line": 78,
+                  "line": 80,
                   "column": 24,
-                  "offset": 1424
+                  "offset": 1494
                 },
                 "indent": []
               }
@@ -2815,14 +2988,14 @@
           ],
           "position": {
             "start": {
-              "line": 78,
+              "line": 80,
               "column": 1,
-              "offset": 1401
+              "offset": 1471
             },
             "end": {
-              "line": 78,
+              "line": 80,
               "column": 24,
-              "offset": 1424
+              "offset": 1494
             },
             "indent": []
           }
@@ -2840,14 +3013,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 5,
-                      "offset": 1429
+                      "offset": 1499
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 9,
-                      "offset": 1433
+                      "offset": 1503
                     },
                     "indent": []
                   }
@@ -2857,14 +3030,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 9,
-                      "offset": 1433
+                      "offset": 1503
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 13,
-                      "offset": 1437
+                      "offset": 1507
                     },
                     "indent": []
                   }
@@ -2874,14 +3047,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 13,
-                      "offset": 1437
+                      "offset": 1507
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 17,
-                      "offset": 1441
+                      "offset": 1511
                     },
                     "indent": []
                   }
@@ -2891,14 +3064,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 17,
-                      "offset": 1441
+                      "offset": 1511
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 22,
-                      "offset": 1446
+                      "offset": 1516
                     },
                     "indent": []
                   }
@@ -2906,14 +3079,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 79,
+                  "line": 81,
                   "column": 5,
-                  "offset": 1429
+                  "offset": 1499
                 },
                 "end": {
-                  "line": 79,
+                  "line": 81,
                   "column": 22,
-                  "offset": 1446
+                  "offset": 1516
                 },
                 "indent": []
               }
@@ -2921,14 +3094,14 @@
           ],
           "position": {
             "start": {
-              "line": 79,
+              "line": 81,
               "column": 1,
-              "offset": 1425
+              "offset": 1495
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 22,
-              "offset": 1446
+              "offset": 1516
             },
             "indent": []
           }
@@ -2946,14 +3119,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 5,
-                      "offset": 1451
+                      "offset": 1521
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 9,
-                      "offset": 1455
+                      "offset": 1525
                     },
                     "indent": []
                   }
@@ -2963,14 +3136,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 9,
-                      "offset": 1455
+                      "offset": 1525
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 13,
-                      "offset": 1459
+                      "offset": 1529
                     },
                     "indent": []
                   }
@@ -2980,14 +3153,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 13,
-                      "offset": 1459
+                      "offset": 1529
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 20,
-                      "offset": 1466
+                      "offset": 1536
                     },
                     "indent": []
                   }
@@ -2997,14 +3170,14 @@
                   "value": "google.com>",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 20,
-                      "offset": 1466
+                      "offset": 1536
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 31,
-                      "offset": 1477
+                      "offset": 1547
                     },
                     "indent": []
                   }
@@ -3012,14 +3185,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 80,
+                  "line": 82,
                   "column": 5,
-                  "offset": 1451
+                  "offset": 1521
                 },
                 "end": {
-                  "line": 80,
+                  "line": 82,
                   "column": 31,
-                  "offset": 1477
+                  "offset": 1547
                 },
                 "indent": []
               }
@@ -3027,14 +3200,14 @@
           ],
           "position": {
             "start": {
-              "line": 80,
+              "line": 82,
               "column": 1,
-              "offset": 1447
+              "offset": 1517
             },
             "end": {
-              "line": 80,
+              "line": 82,
               "column": 31,
-              "offset": 1477
+              "offset": 1547
             },
             "indent": []
           }
@@ -3042,14 +3215,14 @@
       ],
       "position": {
         "start": {
-          "line": 77,
+          "line": 79,
           "column": 1,
-          "offset": 1383
+          "offset": 1453
         },
         "end": {
-          "line": 80,
+          "line": 82,
           "column": 31,
-          "offset": 1477
+          "offset": 1547
         },
         "indent": [
           1,
@@ -3066,9 +3239,9 @@
       "offset": 0
     },
     "end": {
-      "line": 81,
+      "line": 83,
       "column": 1,
-      "offset": 1478
+      "offset": 1548
     }
   }
 }

--- a/test/tree/stringify-escape.output.commonmark.commonmark.json
+++ b/test/tree/stringify-escape.output.commonmark.commonmark.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,115 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in_the_middle_of_a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +354,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +369,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +400,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "indent": []
                   }
@@ -348,14 +417,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "indent": []
                   }
@@ -365,14 +434,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "indent": []
                   }
@@ -382,14 +451,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "indent": []
                   }
@@ -399,14 +468,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "indent": []
                   }
@@ -416,14 +485,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +515,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +540,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 16,
-                      "offset": 232
+                      "offset": 302
                     },
                     "indent": []
                   }
@@ -488,14 +557,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 16,
-                      "offset": 232
+                      "offset": 302
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 27,
-                      "offset": 243
+                      "offset": 313
                     },
                     "indent": []
                   }
@@ -505,14 +574,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 27,
-                      "offset": 243
+                      "offset": 313
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 43,
-                      "offset": 259
+                      "offset": 329
                     },
                     "indent": []
                   }
@@ -520,14 +589,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 43,
-                  "offset": 259
+                  "offset": 329
                 },
                 "indent": []
               }
@@ -535,14 +604,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 43,
-              "offset": 259
+              "offset": 329
             },
             "indent": []
           }
@@ -550,14 +619,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 12,
+          "line": 14,
           "column": 43,
-          "offset": 259
+          "offset": 329
         },
         "indent": [
           1
@@ -572,14 +641,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 14,
+              "line": 16,
               "column": 1,
-              "offset": 261
+              "offset": 331
             },
             "end": {
-              "line": 14,
+              "line": 16,
               "column": 63,
-              "offset": 323
+              "offset": 393
             },
             "indent": []
           }
@@ -587,14 +656,14 @@
       ],
       "position": {
         "start": {
-          "line": 14,
+          "line": 16,
           "column": 1,
-          "offset": 261
+          "offset": 331
         },
         "end": {
-          "line": 14,
+          "line": 16,
           "column": 63,
-          "offset": 323
+          "offset": 393
         },
         "indent": []
       }
@@ -612,14 +681,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 16,
+                  "line": 18,
                   "column": 2,
-                  "offset": 326
+                  "offset": 396
                 },
                 "end": {
-                  "line": 16,
+                  "line": 18,
                   "column": 5,
-                  "offset": 329
+                  "offset": 399
                 },
                 "indent": []
               }
@@ -627,14 +696,14 @@
           ],
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 1,
-              "offset": 325
+              "offset": 395
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 6,
-              "offset": 330
+              "offset": 400
             },
             "indent": []
           }
@@ -644,14 +713,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 6,
-              "offset": 330
+              "offset": 400
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 8,
-              "offset": 332
+              "offset": 402
             },
             "indent": []
           }
@@ -661,14 +730,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 8,
-              "offset": 332
+              "offset": 402
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 13,
-              "offset": 337
+              "offset": 407
             },
             "indent": []
           }
@@ -676,14 +745,14 @@
       ],
       "position": {
         "start": {
-          "line": 16,
+          "line": 18,
           "column": 1,
-          "offset": 325
+          "offset": 395
         },
         "end": {
-          "line": 16,
+          "line": 18,
           "column": 13,
-          "offset": 337
+          "offset": 407
         },
         "indent": []
       }
@@ -696,14 +765,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 18,
+              "line": 20,
               "column": 1,
-              "offset": 339
+              "offset": 409
             },
             "end": {
-              "line": 18,
+              "line": 20,
               "column": 53,
-              "offset": 391
+              "offset": 461
             },
             "indent": []
           }
@@ -711,14 +780,14 @@
       ],
       "position": {
         "start": {
-          "line": 18,
+          "line": 20,
           "column": 1,
-          "offset": 339
+          "offset": 409
         },
         "end": {
-          "line": 18,
+          "line": 20,
           "column": 53,
-          "offset": 391
+          "offset": 461
         },
         "indent": []
       }
@@ -731,14 +800,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 20,
+              "line": 22,
               "column": 1,
-              "offset": 393
+              "offset": 463
             },
             "end": {
-              "line": 20,
+              "line": 22,
               "column": 3,
-              "offset": 395
+              "offset": 465
             },
             "indent": []
           }
@@ -748,14 +817,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 20,
+              "line": 22,
               "column": 3,
-              "offset": 395
+              "offset": 465
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 412
+              "offset": 482
             },
             "indent": [
               1
@@ -767,14 +836,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 412
+              "offset": 482
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 414
+              "offset": 484
             },
             "indent": []
           }
@@ -784,14 +853,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 414
+              "offset": 484
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 433
+              "offset": 503
             },
             "indent": [
               1
@@ -803,14 +872,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 433
+              "offset": 503
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 5,
-              "offset": 435
+              "offset": 505
             },
             "indent": []
           }
@@ -820,14 +889,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 5,
-              "offset": 435
+              "offset": 505
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 21,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -835,14 +904,14 @@
       ],
       "position": {
         "start": {
-          "line": 20,
+          "line": 22,
           "column": 1,
-          "offset": 393
+          "offset": 463
         },
         "end": {
-          "line": 22,
+          "line": 24,
           "column": 21,
-          "offset": 451
+          "offset": 521
         },
         "indent": [
           1,
@@ -858,14 +927,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 24,
+              "line": 26,
               "column": 1,
-              "offset": 453
+              "offset": 523
             },
             "end": {
-              "line": 24,
+              "line": 26,
               "column": 25,
-              "offset": 477
+              "offset": 547
             },
             "indent": []
           }
@@ -873,14 +942,14 @@
       ],
       "position": {
         "start": {
-          "line": 24,
+          "line": 26,
           "column": 1,
-          "offset": 453
+          "offset": 523
         },
         "end": {
-          "line": 24,
+          "line": 26,
           "column": 25,
-          "offset": 477
+          "offset": 547
         },
         "indent": []
       }
@@ -893,14 +962,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 1,
-              "offset": 479
+              "offset": 549
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 3,
-              "offset": 481
+              "offset": 551
             },
             "indent": []
           }
@@ -910,14 +979,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 3,
-              "offset": 481
+              "offset": 551
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 21,
-              "offset": 499
+              "offset": 569
             },
             "indent": []
           }
@@ -925,14 +994,14 @@
       ],
       "position": {
         "start": {
-          "line": 26,
+          "line": 28,
           "column": 1,
-          "offset": 479
+          "offset": 549
         },
         "end": {
-          "line": 26,
+          "line": 28,
           "column": 21,
-          "offset": 499
+          "offset": 569
         },
         "indent": []
       }
@@ -945,14 +1014,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 28,
+              "line": 30,
               "column": 1,
-              "offset": 501
+              "offset": 571
             },
             "end": {
-              "line": 28,
+              "line": 30,
               "column": 16,
-              "offset": 516
+              "offset": 586
             },
             "indent": []
           }
@@ -960,14 +1029,14 @@
       ],
       "position": {
         "start": {
-          "line": 28,
+          "line": 30,
           "column": 1,
-          "offset": 501
+          "offset": 571
         },
         "end": {
-          "line": 28,
+          "line": 30,
           "column": 16,
-          "offset": 516
+          "offset": 586
         },
         "indent": []
       }
@@ -980,14 +1049,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 1,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 30,
+              "line": 32,
               "column": 3,
-              "offset": 520
+              "offset": 590
             },
             "indent": []
           }
@@ -997,14 +1066,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 3,
-              "offset": 520
+              "offset": 590
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 537
+              "offset": 607
             },
             "indent": [
               1
@@ -1016,14 +1085,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 537
+              "offset": 607
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 5,
-              "offset": 539
+              "offset": 609
             },
             "indent": []
           }
@@ -1033,14 +1102,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 5,
-              "offset": 539
+              "offset": 609
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 23,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1048,14 +1117,14 @@
       ],
       "position": {
         "start": {
-          "line": 30,
+          "line": 32,
           "column": 1,
-          "offset": 518
+          "offset": 588
         },
         "end": {
-          "line": 31,
+          "line": 33,
           "column": 23,
-          "offset": 557
+          "offset": 627
         },
         "indent": [
           1
@@ -1070,14 +1139,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 33,
+              "line": 35,
               "column": 1,
-              "offset": 559
+              "offset": 629
             },
             "end": {
-              "line": 33,
+              "line": 35,
               "column": 62,
-              "offset": 620
+              "offset": 690
             },
             "indent": []
           }
@@ -1085,14 +1154,14 @@
       ],
       "position": {
         "start": {
-          "line": 33,
+          "line": 35,
           "column": 1,
-          "offset": 559
+          "offset": 629
         },
         "end": {
-          "line": 33,
+          "line": 35,
           "column": 62,
-          "offset": 620
+          "offset": 690
         },
         "indent": []
       }
@@ -1121,14 +1190,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 35,
+                          "line": 37,
                           "column": 6,
-                          "offset": 627
+                          "offset": 697
                         },
                         "end": {
-                          "line": 35,
+                          "line": 37,
                           "column": 15,
-                          "offset": 636
+                          "offset": 706
                         },
                         "indent": []
                       }
@@ -1136,14 +1205,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 35,
+                      "line": 37,
                       "column": 5,
-                      "offset": 626
+                      "offset": 696
                     },
                     "end": {
-                      "line": 35,
+                      "line": 37,
                       "column": 16,
-                      "offset": 637
+                      "offset": 707
                     },
                     "indent": []
                   }
@@ -1151,14 +1220,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 35,
+                  "line": 37,
                   "column": 5,
-                  "offset": 626
+                  "offset": 696
                 },
                 "end": {
-                  "line": 35,
+                  "line": 37,
                   "column": 16,
-                  "offset": 637
+                  "offset": 707
                 },
                 "indent": []
               }
@@ -1166,14 +1235,14 @@
           ],
           "position": {
             "start": {
-              "line": 35,
+              "line": 37,
               "column": 1,
-              "offset": 622
+              "offset": 692
             },
             "end": {
-              "line": 35,
+              "line": 37,
               "column": 16,
-              "offset": 637
+              "offset": 707
             },
             "indent": []
           }
@@ -1196,14 +1265,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 643
+                          "offset": 713
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 9,
-                          "offset": 646
+                          "offset": 716
                         },
                         "indent": []
                       }
@@ -1213,14 +1282,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 9,
-                          "offset": 646
+                          "offset": 716
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 11,
-                          "offset": 648
+                          "offset": 718
                         },
                         "indent": []
                       }
@@ -1230,14 +1299,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 11,
-                          "offset": 648
+                          "offset": 718
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 16,
-                          "offset": 653
+                          "offset": 723
                         },
                         "indent": []
                       }
@@ -1245,14 +1314,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 642
+                      "offset": 712
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 17,
-                      "offset": 654
+                      "offset": 724
                     },
                     "indent": []
                   }
@@ -1260,14 +1329,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 642
+                  "offset": 712
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 17,
-                  "offset": 654
+                  "offset": 724
                 },
                 "indent": []
               }
@@ -1275,14 +1344,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 638
+              "offset": 708
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 17,
-              "offset": 654
+              "offset": 724
             },
             "indent": []
           }
@@ -1305,14 +1374,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 660
+                          "offset": 730
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 663
+                          "offset": 733
                         },
                         "indent": []
                       }
@@ -1320,14 +1389,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 659
+                      "offset": 729
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 10,
-                      "offset": 664
+                      "offset": 734
                     },
                     "indent": []
                   }
@@ -1335,14 +1404,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 659
+                  "offset": 729
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 10,
-                  "offset": 664
+                  "offset": 734
                 },
                 "indent": []
               }
@@ -1350,14 +1419,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 655
+              "offset": 725
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 10,
-              "offset": 664
+              "offset": 734
             },
             "indent": []
           }
@@ -1380,14 +1449,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 670
+                          "offset": 740
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 7,
-                          "offset": 671
+                          "offset": 741
                         },
                         "indent": []
                       }
@@ -1397,14 +1466,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 7,
-                          "offset": 671
+                          "offset": 741
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1414,14 +1483,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 673
+                          "offset": 743
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 10,
-                          "offset": 674
+                          "offset": 744
                         },
                         "indent": []
                       }
@@ -1429,14 +1498,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 669
+                      "offset": 739
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 11,
-                      "offset": 675
+                      "offset": 745
                     },
                     "indent": []
                   }
@@ -1444,14 +1513,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 669
+                  "offset": 739
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 11,
-                  "offset": 675
+                  "offset": 745
                 },
                 "indent": []
               }
@@ -1459,14 +1528,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 665
+              "offset": 735
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 11,
-              "offset": 675
+              "offset": 745
             },
             "indent": []
           }
@@ -1489,14 +1558,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 681
+                          "offset": 751
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 682
+                          "offset": 752
                         },
                         "indent": []
                       }
@@ -1506,14 +1575,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 682
+                          "offset": 752
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 684
+                          "offset": 754
                         },
                         "indent": []
                       }
@@ -1523,14 +1592,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 684
+                          "offset": 754
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 11,
-                          "offset": 686
+                          "offset": 756
                         },
                         "indent": []
                       }
@@ -1538,14 +1607,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 680
+                      "offset": 750
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 12,
-                      "offset": 687
+                      "offset": 757
                     },
                     "indent": []
                   }
@@ -1553,14 +1622,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 680
+                  "offset": 750
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 12,
-                  "offset": 687
+                  "offset": 757
                 },
                 "indent": []
               }
@@ -1568,14 +1637,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 676
+              "offset": 746
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 12,
-              "offset": 687
+              "offset": 757
             },
             "indent": []
           }
@@ -1598,14 +1667,14 @@
                       "value": "a_a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 693
+                          "offset": 763
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 696
+                          "offset": 766
                         },
                         "indent": []
                       }
@@ -1615,14 +1684,14 @@
                       "value": "_",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 696
+                          "offset": 766
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 698
+                          "offset": 768
                         },
                         "indent": []
                       }
@@ -1632,14 +1701,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 698
+                          "offset": 768
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 12,
-                          "offset": 699
+                          "offset": 769
                         },
                         "indent": []
                       }
@@ -1647,14 +1716,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 692
+                      "offset": 762
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 13,
-                      "offset": 700
+                      "offset": 770
                     },
                     "indent": []
                   }
@@ -1662,14 +1731,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 692
+                  "offset": 762
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 13,
-                  "offset": 700
+                  "offset": 770
                 },
                 "indent": []
               }
@@ -1677,14 +1746,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 688
+              "offset": 758
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 13,
-              "offset": 700
+              "offset": 770
             },
             "indent": []
           }
@@ -1692,14 +1761,14 @@
       ],
       "position": {
         "start": {
-          "line": 35,
+          "line": 37,
           "column": 1,
-          "offset": 622
+          "offset": 692
         },
         "end": {
-          "line": 40,
+          "line": 42,
           "column": 13,
-          "offset": 700
+          "offset": 770
         },
         "indent": [
           1,
@@ -1721,14 +1790,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 42,
+                  "line": 44,
                   "column": 3,
-                  "offset": 704
+                  "offset": 774
                 },
                 "end": {
-                  "line": 42,
+                  "line": 44,
                   "column": 7,
-                  "offset": 708
+                  "offset": 778
                 },
                 "indent": []
               }
@@ -1736,14 +1805,14 @@
           ],
           "position": {
             "start": {
-              "line": 42,
+              "line": 44,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 42,
+              "line": 44,
               "column": 9,
-              "offset": 710
+              "offset": 780
             },
             "indent": []
           }
@@ -1751,14 +1820,14 @@
       ],
       "position": {
         "start": {
-          "line": 42,
+          "line": 44,
           "column": 1,
-          "offset": 702
+          "offset": 772
         },
         "end": {
-          "line": 42,
+          "line": 44,
           "column": 9,
-          "offset": 710
+          "offset": 780
         },
         "indent": []
       }
@@ -1771,14 +1840,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 44,
+              "line": 46,
               "column": 1,
-              "offset": 712
+              "offset": 782
             },
             "end": {
-              "line": 44,
+              "line": 46,
               "column": 33,
-              "offset": 744
+              "offset": 814
             },
             "indent": []
           }
@@ -1786,14 +1855,14 @@
       ],
       "position": {
         "start": {
-          "line": 44,
+          "line": 46,
           "column": 1,
-          "offset": 712
+          "offset": 782
         },
         "end": {
-          "line": 44,
+          "line": 46,
           "column": 33,
-          "offset": 744
+          "offset": 814
         },
         "indent": []
       }
@@ -1817,14 +1886,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 46,
+                      "line": 48,
                       "column": 5,
-                      "offset": 750
+                      "offset": 820
                     },
                     "end": {
-                      "line": 46,
+                      "line": 48,
                       "column": 9,
-                      "offset": 754
+                      "offset": 824
                     },
                     "indent": []
                   }
@@ -1834,14 +1903,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 46,
+                      "line": 48,
                       "column": 9,
-                      "offset": 754
+                      "offset": 824
                     },
                     "end": {
-                      "line": 46,
+                      "line": 48,
                       "column": 11,
-                      "offset": 756
+                      "offset": 826
                     },
                     "indent": []
                   }
@@ -1851,14 +1920,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 46,
+                      "line": 48,
                       "column": 11,
-                      "offset": 756
+                      "offset": 826
                     },
                     "end": {
-                      "line": 46,
+                      "line": 48,
                       "column": 60,
-                      "offset": 805
+                      "offset": 875
                     },
                     "indent": []
                   }
@@ -1866,14 +1935,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 46,
+                  "line": 48,
                   "column": 5,
-                  "offset": 750
+                  "offset": 820
                 },
                 "end": {
-                  "line": 46,
+                  "line": 48,
                   "column": 60,
-                  "offset": 805
+                  "offset": 875
                 },
                 "indent": []
               }
@@ -1881,14 +1950,14 @@
           ],
           "position": {
             "start": {
-              "line": 46,
+              "line": 48,
               "column": 1,
-              "offset": 746
+              "offset": 816
             },
             "end": {
-              "line": 46,
+              "line": 48,
               "column": 60,
-              "offset": 805
+              "offset": 875
             },
             "indent": []
           }
@@ -1906,14 +1975,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 810
+                      "offset": 880
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 10,
-                      "offset": 815
+                      "offset": 885
                     },
                     "indent": []
                   }
@@ -1923,14 +1992,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 10,
-                      "offset": 815
+                      "offset": 885
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 12,
-                      "offset": 817
+                      "offset": 887
                     },
                     "indent": []
                   }
@@ -1940,14 +2009,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 12,
-                      "offset": 817
+                      "offset": 887
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 61,
-                      "offset": 866
+                      "offset": 936
                     },
                     "indent": []
                   }
@@ -1955,14 +2024,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 810
+                  "offset": 880
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 61,
-                  "offset": 866
+                  "offset": 936
                 },
                 "indent": []
               }
@@ -1970,14 +2039,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 806
+              "offset": 876
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 61,
-              "offset": 866
+              "offset": 936
             },
             "indent": []
           }
@@ -1985,14 +2054,14 @@
       ],
       "position": {
         "start": {
-          "line": 46,
+          "line": 48,
           "column": 1,
-          "offset": 746
+          "offset": 816
         },
         "end": {
-          "line": 47,
+          "line": 49,
           "column": 61,
-          "offset": 866
+          "offset": 936
         },
         "indent": [
           1
@@ -2007,14 +2076,14 @@
           "value": "Double tildes should be ",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 868
+              "offset": 938
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 25,
-              "offset": 892
+              "offset": 962
             },
             "indent": []
           }
@@ -2024,14 +2093,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 25,
-              "offset": 892
+              "offset": 962
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 27,
-              "offset": 894
+              "offset": 964
             },
             "indent": []
           }
@@ -2041,14 +2110,14 @@
           "value": "~escaped",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 27,
-              "offset": 894
+              "offset": 964
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 35,
-              "offset": 902
+              "offset": 972
             },
             "indent": []
           }
@@ -2058,14 +2127,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 35,
-              "offset": 902
+              "offset": 972
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 37,
-              "offset": 904
+              "offset": 974
             },
             "indent": []
           }
@@ -2075,14 +2144,14 @@
           "value": "~.\nAnd here: foo",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 37,
-              "offset": 904
+              "offset": 974
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 14,
-              "offset": 920
+              "offset": 990
             },
             "indent": [
               1
@@ -2094,14 +2163,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 14,
-              "offset": 920
+              "offset": 990
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 16,
-              "offset": 922
+              "offset": 992
             },
             "indent": []
           }
@@ -2111,14 +2180,14 @@
           "value": "~.",
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 16,
-              "offset": 922
+              "offset": 992
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 18,
-              "offset": 924
+              "offset": 994
             },
             "indent": []
           }
@@ -2126,14 +2195,14 @@
       ],
       "position": {
         "start": {
-          "line": 49,
+          "line": 51,
           "column": 1,
-          "offset": 868
+          "offset": 938
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 18,
-          "offset": 924
+          "offset": 994
         },
         "indent": [
           1
@@ -2148,14 +2217,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 926
+              "offset": 996
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 36,
-              "offset": 961
+              "offset": 1031
             },
             "indent": []
           }
@@ -2163,14 +2232,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 926
+          "offset": 996
         },
         "end": {
-          "line": 52,
+          "line": 54,
           "column": 36,
-          "offset": 961
+          "offset": 1031
         },
         "indent": []
       }
@@ -2193,14 +2262,14 @@
                   "value": "here",
                   "position": {
                     "start": {
-                      "line": 54,
+                      "line": 56,
                       "column": 3,
-                      "offset": 965
+                      "offset": 1035
                     },
                     "end": {
-                      "line": 54,
+                      "line": 56,
                       "column": 7,
-                      "offset": 969
+                      "offset": 1039
                     },
                     "indent": []
                   }
@@ -2208,14 +2277,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 54,
+                  "line": 56,
                   "column": 3,
-                  "offset": 965
+                  "offset": 1035
                 },
                 "end": {
-                  "line": 54,
+                  "line": 56,
                   "column": 9,
-                  "offset": 971
+                  "offset": 1041
                 },
                 "indent": []
               }
@@ -2228,14 +2297,14 @@
                   "value": "they",
                   "position": {
                     "start": {
-                      "line": 54,
+                      "line": 56,
                       "column": 12,
-                      "offset": 974
+                      "offset": 1044
                     },
                     "end": {
-                      "line": 54,
+                      "line": 56,
                       "column": 16,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "indent": []
                   }
@@ -2243,14 +2312,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 54,
+                  "line": 56,
                   "column": 12,
-                  "offset": 974
+                  "offset": 1044
                 },
                 "end": {
-                  "line": 54,
+                  "line": 56,
                   "column": 20,
-                  "offset": 982
+                  "offset": 1052
                 },
                 "indent": []
               }
@@ -2258,14 +2327,14 @@
           ],
           "position": {
             "start": {
-              "line": 54,
+              "line": 56,
               "column": 1,
-              "offset": 963
+              "offset": 1033
             },
             "end": {
-              "line": 54,
+              "line": 56,
               "column": 22,
-              "offset": 984
+              "offset": 1054
             },
             "indent": []
           }
@@ -2281,14 +2350,14 @@
                   "value": "should",
                   "position": {
                     "start": {
-                      "line": 56,
+                      "line": 58,
                       "column": 3,
-                      "offset": 1009
+                      "offset": 1079
                     },
                     "end": {
-                      "line": 56,
+                      "line": 58,
                       "column": 9,
-                      "offset": 1015
+                      "offset": 1085
                     },
                     "indent": []
                   }
@@ -2296,14 +2365,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 56,
+                  "line": 58,
                   "column": 3,
-                  "offset": 1009
+                  "offset": 1079
                 },
                 "end": {
-                  "line": 56,
+                  "line": 58,
                   "column": 9,
-                  "offset": 1015
+                  "offset": 1085
                 },
                 "indent": []
               }
@@ -2316,14 +2385,14 @@
                   "value": "tho",
                   "position": {
                     "start": {
-                      "line": 56,
+                      "line": 58,
                       "column": 12,
-                      "offset": 1018
+                      "offset": 1088
                     },
                     "end": {
-                      "line": 56,
+                      "line": 58,
                       "column": 15,
-                      "offset": 1021
+                      "offset": 1091
                     },
                     "indent": []
                   }
@@ -2333,14 +2402,14 @@
                   "value": "|",
                   "position": {
                     "start": {
-                      "line": 56,
+                      "line": 58,
                       "column": 15,
-                      "offset": 1021
+                      "offset": 1091
                     },
                     "end": {
-                      "line": 56,
+                      "line": 58,
                       "column": 17,
-                      "offset": 1023
+                      "offset": 1093
                     },
                     "indent": []
                   }
@@ -2350,14 +2419,14 @@
                   "value": "ugh",
                   "position": {
                     "start": {
-                      "line": 56,
+                      "line": 58,
                       "column": 17,
-                      "offset": 1023
+                      "offset": 1093
                     },
                     "end": {
-                      "line": 56,
+                      "line": 58,
                       "column": 20,
-                      "offset": 1026
+                      "offset": 1096
                     },
                     "indent": []
                   }
@@ -2365,14 +2434,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 56,
+                  "line": 58,
                   "column": 12,
-                  "offset": 1018
+                  "offset": 1088
                 },
                 "end": {
-                  "line": 56,
+                  "line": 58,
                   "column": 20,
-                  "offset": 1026
+                  "offset": 1096
                 },
                 "indent": []
               }
@@ -2380,14 +2449,14 @@
           ],
           "position": {
             "start": {
-              "line": 56,
+              "line": 58,
               "column": 1,
-              "offset": 1007
+              "offset": 1077
             },
             "end": {
-              "line": 56,
+              "line": 58,
               "column": 22,
-              "offset": 1028
+              "offset": 1098
             },
             "indent": []
           }
@@ -2395,14 +2464,14 @@
       ],
       "position": {
         "start": {
-          "line": 54,
+          "line": 56,
           "column": 1,
-          "offset": 963
+          "offset": 1033
         },
         "end": {
-          "line": 56,
+          "line": 58,
           "column": 22,
-          "offset": 1028
+          "offset": 1098
         },
         "indent": [
           1,
@@ -2418,14 +2487,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 58,
+              "line": 60,
               "column": 1,
-              "offset": 1030
+              "offset": 1100
             },
             "end": {
-              "line": 58,
+              "line": 60,
               "column": 10,
-              "offset": 1039
+              "offset": 1109
             },
             "indent": []
           }
@@ -2433,14 +2502,14 @@
       ],
       "position": {
         "start": {
-          "line": 58,
+          "line": 60,
           "column": 1,
-          "offset": 1030
+          "offset": 1100
         },
         "end": {
-          "line": 58,
+          "line": 60,
           "column": 10,
-          "offset": 1039
+          "offset": 1109
         },
         "indent": []
       }
@@ -2453,14 +2522,14 @@
           "value": "| here   | they   |\n",
           "position": {
             "start": {
-              "line": 60,
+              "line": 62,
               "column": 1,
-              "offset": 1041
+              "offset": 1111
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1061
+              "offset": 1131
             },
             "indent": [
               1
@@ -2472,14 +2541,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1061
+              "offset": 1131
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 3,
-              "offset": 1063
+              "offset": 1133
             },
             "indent": []
           }
@@ -2489,14 +2558,14 @@
           "value": " ---- ",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 3,
-              "offset": 1063
+              "offset": 1133
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 9,
-              "offset": 1069
+              "offset": 1139
             },
             "indent": []
           }
@@ -2506,14 +2575,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 9,
-              "offset": 1069
+              "offset": 1139
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 11,
-              "offset": 1071
+              "offset": 1141
             },
             "indent": []
           }
@@ -2523,14 +2592,14 @@
           "value": " ----- ",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 11,
-              "offset": 1071
+              "offset": 1141
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 18,
-              "offset": 1078
+              "offset": 1148
             },
             "indent": []
           }
@@ -2540,14 +2609,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 18,
-              "offset": 1078
+              "offset": 1148
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 20,
-              "offset": 1080
+              "offset": 1150
             },
             "indent": []
           }
@@ -2557,14 +2626,14 @@
           "value": "\n| should | though |",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 20,
-              "offset": 1080
+              "offset": 1150
             },
             "end": {
-              "line": 62,
+              "line": 64,
               "column": 20,
-              "offset": 1100
+              "offset": 1170
             },
             "indent": [
               1
@@ -2574,14 +2643,14 @@
       ],
       "position": {
         "start": {
-          "line": 60,
+          "line": 62,
           "column": 1,
-          "offset": 1041
+          "offset": 1111
         },
         "end": {
-          "line": 62,
+          "line": 64,
           "column": 20,
-          "offset": 1100
+          "offset": 1170
         },
         "indent": [
           1,
@@ -2597,14 +2666,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1102
+              "offset": 1172
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 10,
-              "offset": 1111
+              "offset": 1181
             },
             "indent": []
           }
@@ -2612,14 +2681,14 @@
       ],
       "position": {
         "start": {
-          "line": 64,
+          "line": 66,
           "column": 1,
-          "offset": 1102
+          "offset": 1172
         },
         "end": {
-          "line": 64,
+          "line": 66,
           "column": 10,
-          "offset": 1111
+          "offset": 1181
         },
         "indent": []
       }
@@ -2632,14 +2701,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 66,
+              "line": 68,
               "column": 1,
-              "offset": 1113
+              "offset": 1183
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1127
+              "offset": 1197
             },
             "indent": [
               1
@@ -2651,14 +2720,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1127
+              "offset": 1197
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 3,
-              "offset": 1129
+              "offset": 1199
             },
             "indent": []
           }
@@ -2668,14 +2737,14 @@
           "value": "--- ",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 3,
-              "offset": 1129
+              "offset": 1199
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 7,
-              "offset": 1133
+              "offset": 1203
             },
             "indent": []
           }
@@ -2685,14 +2754,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 7,
-              "offset": 1133
+              "offset": 1203
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 9,
-              "offset": 1135
+              "offset": 1205
             },
             "indent": []
           }
@@ -2702,14 +2771,14 @@
           "value": " ------\nshould | though",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 9,
-              "offset": 1135
+              "offset": 1205
             },
             "end": {
-              "line": 68,
+              "line": 70,
               "column": 16,
-              "offset": 1158
+              "offset": 1228
             },
             "indent": [
               1
@@ -2719,14 +2788,14 @@
       ],
       "position": {
         "start": {
-          "line": 66,
+          "line": 68,
           "column": 1,
-          "offset": 1113
+          "offset": 1183
         },
         "end": {
-          "line": 68,
+          "line": 70,
           "column": 16,
-          "offset": 1158
+          "offset": 1228
         },
         "indent": [
           1,
@@ -2745,14 +2814,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 70,
+                  "line": 72,
                   "column": 3,
-                  "offset": 1162
+                  "offset": 1232
                 },
                 "end": {
-                  "line": 70,
+                  "line": 72,
                   "column": 14,
-                  "offset": 1173
+                  "offset": 1243
                 },
                 "indent": []
               }
@@ -2760,14 +2829,14 @@
           ],
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1160
+              "offset": 1230
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 16,
-              "offset": 1175
+              "offset": 1245
             },
             "indent": []
           }
@@ -2775,14 +2844,14 @@
       ],
       "position": {
         "start": {
-          "line": 70,
+          "line": 72,
           "column": 1,
-          "offset": 1160
+          "offset": 1230
         },
         "end": {
-          "line": 70,
+          "line": 72,
           "column": 16,
-          "offset": 1175
+          "offset": 1245
         },
         "indent": []
       }
@@ -2795,14 +2864,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 72,
+              "line": 74,
               "column": 1,
-              "offset": 1177
+              "offset": 1247
             },
             "end": {
-              "line": 72,
+              "line": 74,
               "column": 38,
-              "offset": 1214
+              "offset": 1284
             },
             "indent": []
           }
@@ -2810,14 +2879,14 @@
       ],
       "position": {
         "start": {
-          "line": 72,
+          "line": 74,
           "column": 1,
-          "offset": 1177
+          "offset": 1247
         },
         "end": {
-          "line": 72,
+          "line": 74,
           "column": 38,
-          "offset": 1214
+          "offset": 1284
         },
         "indent": []
       }
@@ -2841,14 +2910,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 5,
-                      "offset": 1220
+                      "offset": 1290
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 7,
-                      "offset": 1222
+                      "offset": 1292
                     },
                     "indent": []
                   }
@@ -2858,14 +2927,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 7,
-                      "offset": 1222
+                      "offset": 1292
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 11,
-                      "offset": 1226
+                      "offset": 1296
                     },
                     "indent": []
                   }
@@ -2875,14 +2944,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 11,
-                      "offset": 1226
+                      "offset": 1296
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 13,
-                      "offset": 1228
+                      "offset": 1298
                     },
                     "indent": []
                   }
@@ -2892,14 +2961,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 13,
-                      "offset": 1228
+                      "offset": 1298
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 18,
-                      "offset": 1233
+                      "offset": 1303
                     },
                     "indent": []
                   }
@@ -2907,14 +2976,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 74,
+                  "line": 76,
                   "column": 5,
-                  "offset": 1220
+                  "offset": 1290
                 },
                 "end": {
-                  "line": 74,
+                  "line": 76,
                   "column": 18,
-                  "offset": 1233
+                  "offset": 1303
                 },
                 "indent": []
               }
@@ -2922,14 +2991,14 @@
           ],
           "position": {
             "start": {
-              "line": 74,
+              "line": 76,
               "column": 1,
-              "offset": 1216
+              "offset": 1286
             },
             "end": {
-              "line": 74,
+              "line": 76,
               "column": 18,
-              "offset": 1233
+              "offset": 1303
             },
             "indent": []
           }
@@ -2947,14 +3016,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 5,
-                      "offset": 1238
+                      "offset": 1308
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 7,
-                      "offset": 1240
+                      "offset": 1310
                     },
                     "indent": []
                   }
@@ -2964,14 +3033,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 7,
-                      "offset": 1240
+                      "offset": 1310
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 11,
-                      "offset": 1244
+                      "offset": 1314
                     },
                     "indent": []
                   }
@@ -2981,14 +3050,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 11,
-                      "offset": 1244
+                      "offset": 1314
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 13,
-                      "offset": 1246
+                      "offset": 1316
                     },
                     "indent": []
                   }
@@ -2998,14 +3067,14 @@
                   "value": "google.com>",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 13,
-                      "offset": 1246
+                      "offset": 1316
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 24,
-                      "offset": 1257
+                      "offset": 1327
                     },
                     "indent": []
                   }
@@ -3013,14 +3082,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 75,
+                  "line": 77,
                   "column": 5,
-                  "offset": 1238
+                  "offset": 1308
                 },
                 "end": {
-                  "line": 75,
+                  "line": 77,
                   "column": 24,
-                  "offset": 1257
+                  "offset": 1327
                 },
                 "indent": []
               }
@@ -3028,14 +3097,14 @@
           ],
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1234
+              "offset": 1304
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 24,
-              "offset": 1257
+              "offset": 1327
             },
             "indent": []
           }
@@ -3043,14 +3112,14 @@
       ],
       "position": {
         "start": {
-          "line": 74,
+          "line": 76,
           "column": 1,
-          "offset": 1216
+          "offset": 1286
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 24,
-          "offset": 1257
+          "offset": 1327
         },
         "indent": [
           1
@@ -3065,9 +3134,9 @@
       "offset": 0
     },
     "end": {
-      "line": 76,
+      "line": 78,
       "column": 1,
-      "offset": 1258
+      "offset": 1328
     }
   }
 }

--- a/test/tree/stringify-escape.output.json
+++ b/test/tree/stringify-escape.output.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,115 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in_the_middle_of_a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +354,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +369,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +400,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 10,
-                      "offset": 198
+                      "offset": 268
                     },
                     "indent": []
                   }
@@ -348,14 +417,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 10,
-                      "offset": 198
+                      "offset": 268
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 18,
-                      "offset": 206
+                      "offset": 276
                     },
                     "indent": []
                   }
@@ -365,14 +434,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 18,
-                      "offset": 206
+                      "offset": 276
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "indent": []
                   }
@@ -382,14 +451,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -399,14 +468,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 33,
-                      "offset": 221
+                      "offset": 291
                     },
                     "indent": []
                   }
@@ -416,14 +485,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 33,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 37,
-                      "offset": 225
+                      "offset": 295
                     },
                     "indent": []
                   }
@@ -431,14 +500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 37,
-                  "offset": 225
+                  "offset": 295
                 },
                 "indent": []
               }
@@ -446,14 +515,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 37,
-              "offset": 225
+              "offset": 295
             },
             "indent": []
           }
@@ -471,14 +540,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 230
+                      "offset": 300
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 16,
-                      "offset": 241
+                      "offset": 311
                     },
                     "indent": []
                   }
@@ -488,14 +557,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 16,
-                      "offset": 241
+                      "offset": 311
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 27,
-                      "offset": 252
+                      "offset": 322
                     },
                     "indent": []
                   }
@@ -505,14 +574,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 27,
-                      "offset": 252
+                      "offset": 322
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 43,
-                      "offset": 268
+                      "offset": 338
                     },
                     "indent": []
                   }
@@ -520,14 +589,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 230
+                  "offset": 300
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 43,
-                  "offset": 268
+                  "offset": 338
                 },
                 "indent": []
               }
@@ -535,14 +604,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 226
+              "offset": 296
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 43,
-              "offset": 268
+              "offset": 338
             },
             "indent": []
           }
@@ -550,14 +619,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 12,
+          "line": 14,
           "column": 43,
-          "offset": 268
+          "offset": 338
         },
         "indent": [
           1
@@ -572,14 +641,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 14,
+              "line": 16,
               "column": 1,
-              "offset": 270
+              "offset": 340
             },
             "end": {
-              "line": 14,
+              "line": 16,
               "column": 63,
-              "offset": 332
+              "offset": 402
             },
             "indent": []
           }
@@ -587,14 +656,14 @@
       ],
       "position": {
         "start": {
-          "line": 14,
+          "line": 16,
           "column": 1,
-          "offset": 270
+          "offset": 340
         },
         "end": {
-          "line": 14,
+          "line": 16,
           "column": 63,
-          "offset": 332
+          "offset": 402
         },
         "indent": []
       }
@@ -612,14 +681,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 16,
+                  "line": 18,
                   "column": 2,
-                  "offset": 335
+                  "offset": 405
                 },
                 "end": {
-                  "line": 16,
+                  "line": 18,
                   "column": 5,
-                  "offset": 338
+                  "offset": 408
                 },
                 "indent": []
               }
@@ -627,14 +696,14 @@
           ],
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 1,
-              "offset": 334
+              "offset": 404
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 6,
-              "offset": 339
+              "offset": 409
             },
             "indent": []
           }
@@ -644,14 +713,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 6,
-              "offset": 339
+              "offset": 409
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 8,
-              "offset": 341
+              "offset": 411
             },
             "indent": []
           }
@@ -661,14 +730,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 8,
-              "offset": 341
+              "offset": 411
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 13,
-              "offset": 346
+              "offset": 416
             },
             "indent": []
           }
@@ -676,14 +745,14 @@
       ],
       "position": {
         "start": {
-          "line": 16,
+          "line": 18,
           "column": 1,
-          "offset": 334
+          "offset": 404
         },
         "end": {
-          "line": 16,
+          "line": 18,
           "column": 13,
-          "offset": 346
+          "offset": 416
         },
         "indent": []
       }
@@ -696,14 +765,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 18,
+              "line": 20,
               "column": 1,
-              "offset": 348
+              "offset": 418
             },
             "end": {
-              "line": 18,
+              "line": 20,
               "column": 53,
-              "offset": 400
+              "offset": 470
             },
             "indent": []
           }
@@ -711,14 +780,14 @@
       ],
       "position": {
         "start": {
-          "line": 18,
+          "line": 20,
           "column": 1,
-          "offset": 348
+          "offset": 418
         },
         "end": {
-          "line": 18,
+          "line": 20,
           "column": 53,
-          "offset": 400
+          "offset": 470
         },
         "indent": []
       }
@@ -731,14 +800,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 20,
+              "line": 22,
               "column": 1,
-              "offset": 402
+              "offset": 472
             },
             "end": {
-              "line": 20,
+              "line": 22,
               "column": 3,
-              "offset": 404
+              "offset": 474
             },
             "indent": []
           }
@@ -748,14 +817,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 20,
+              "line": 22,
               "column": 3,
-              "offset": 404
+              "offset": 474
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 421
+              "offset": 491
             },
             "indent": [
               1
@@ -767,14 +836,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 421
+              "offset": 491
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 423
+              "offset": 493
             },
             "indent": []
           }
@@ -784,14 +853,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 423
+              "offset": 493
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 442
+              "offset": 512
             },
             "indent": [
               1
@@ -803,14 +872,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 442
+              "offset": 512
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 5,
-              "offset": 444
+              "offset": 514
             },
             "indent": []
           }
@@ -820,14 +889,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 5,
-              "offset": 444
+              "offset": 514
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 21,
-              "offset": 460
+              "offset": 530
             },
             "indent": []
           }
@@ -835,14 +904,14 @@
       ],
       "position": {
         "start": {
-          "line": 20,
+          "line": 22,
           "column": 1,
-          "offset": 402
+          "offset": 472
         },
         "end": {
-          "line": 22,
+          "line": 24,
           "column": 21,
-          "offset": 460
+          "offset": 530
         },
         "indent": [
           1,
@@ -858,14 +927,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 24,
+              "line": 26,
               "column": 1,
-              "offset": 462
+              "offset": 532
             },
             "end": {
-              "line": 24,
+              "line": 26,
               "column": 25,
-              "offset": 486
+              "offset": 556
             },
             "indent": []
           }
@@ -873,14 +942,14 @@
       ],
       "position": {
         "start": {
-          "line": 24,
+          "line": 26,
           "column": 1,
-          "offset": 462
+          "offset": 532
         },
         "end": {
-          "line": 24,
+          "line": 26,
           "column": 25,
-          "offset": 486
+          "offset": 556
         },
         "indent": []
       }
@@ -893,14 +962,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 1,
-              "offset": 488
+              "offset": 558
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 3,
-              "offset": 490
+              "offset": 560
             },
             "indent": []
           }
@@ -910,14 +979,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 3,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 21,
-              "offset": 508
+              "offset": 578
             },
             "indent": []
           }
@@ -925,14 +994,14 @@
       ],
       "position": {
         "start": {
-          "line": 26,
+          "line": 28,
           "column": 1,
-          "offset": 488
+          "offset": 558
         },
         "end": {
-          "line": 26,
+          "line": 28,
           "column": 21,
-          "offset": 508
+          "offset": 578
         },
         "indent": []
       }
@@ -945,14 +1014,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 28,
+              "line": 30,
               "column": 1,
-              "offset": 510
+              "offset": 580
             },
             "end": {
-              "line": 28,
+              "line": 30,
               "column": 16,
-              "offset": 525
+              "offset": 595
             },
             "indent": []
           }
@@ -960,14 +1029,14 @@
       ],
       "position": {
         "start": {
-          "line": 28,
+          "line": 30,
           "column": 1,
-          "offset": 510
+          "offset": 580
         },
         "end": {
-          "line": 28,
+          "line": 30,
           "column": 16,
-          "offset": 525
+          "offset": 595
         },
         "indent": []
       }
@@ -980,14 +1049,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 1,
-              "offset": 527
+              "offset": 597
             },
             "end": {
-              "line": 30,
+              "line": 32,
               "column": 3,
-              "offset": 529
+              "offset": 599
             },
             "indent": []
           }
@@ -997,14 +1066,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 3,
-              "offset": 529
+              "offset": 599
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 546
+              "offset": 616
             },
             "indent": [
               1
@@ -1016,14 +1085,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 546
+              "offset": 616
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 5,
-              "offset": 548
+              "offset": 618
             },
             "indent": []
           }
@@ -1033,14 +1102,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 5,
-              "offset": 548
+              "offset": 618
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 23,
-              "offset": 566
+              "offset": 636
             },
             "indent": []
           }
@@ -1048,14 +1117,14 @@
       ],
       "position": {
         "start": {
-          "line": 30,
+          "line": 32,
           "column": 1,
-          "offset": 527
+          "offset": 597
         },
         "end": {
-          "line": 31,
+          "line": 33,
           "column": 23,
-          "offset": 566
+          "offset": 636
         },
         "indent": [
           1
@@ -1070,14 +1139,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 33,
+              "line": 35,
               "column": 1,
-              "offset": 568
+              "offset": 638
             },
             "end": {
-              "line": 33,
+              "line": 35,
               "column": 62,
-              "offset": 629
+              "offset": 699
             },
             "indent": []
           }
@@ -1085,14 +1154,14 @@
       ],
       "position": {
         "start": {
-          "line": 33,
+          "line": 35,
           "column": 1,
-          "offset": 568
+          "offset": 638
         },
         "end": {
-          "line": 33,
+          "line": 35,
           "column": 62,
-          "offset": 629
+          "offset": 699
         },
         "indent": []
       }
@@ -1121,14 +1190,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 35,
+                          "line": 37,
                           "column": 6,
-                          "offset": 636
+                          "offset": 706
                         },
                         "end": {
-                          "line": 35,
+                          "line": 37,
                           "column": 15,
-                          "offset": 645
+                          "offset": 715
                         },
                         "indent": []
                       }
@@ -1136,14 +1205,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 35,
+                      "line": 37,
                       "column": 5,
-                      "offset": 635
+                      "offset": 705
                     },
                     "end": {
-                      "line": 35,
+                      "line": 37,
                       "column": 16,
-                      "offset": 646
+                      "offset": 716
                     },
                     "indent": []
                   }
@@ -1151,14 +1220,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 35,
+                  "line": 37,
                   "column": 5,
-                  "offset": 635
+                  "offset": 705
                 },
                 "end": {
-                  "line": 35,
+                  "line": 37,
                   "column": 16,
-                  "offset": 646
+                  "offset": 716
                 },
                 "indent": []
               }
@@ -1166,14 +1235,14 @@
           ],
           "position": {
             "start": {
-              "line": 35,
+              "line": 37,
               "column": 1,
-              "offset": 631
+              "offset": 701
             },
             "end": {
-              "line": 35,
+              "line": 37,
               "column": 16,
-              "offset": 646
+              "offset": 716
             },
             "indent": []
           }
@@ -1196,14 +1265,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 652
+                          "offset": 722
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 9,
-                          "offset": 655
+                          "offset": 725
                         },
                         "indent": []
                       }
@@ -1213,14 +1282,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 9,
-                          "offset": 655
+                          "offset": 725
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 11,
-                          "offset": 657
+                          "offset": 727
                         },
                         "indent": []
                       }
@@ -1230,14 +1299,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 11,
-                          "offset": 657
+                          "offset": 727
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 16,
-                          "offset": 662
+                          "offset": 732
                         },
                         "indent": []
                       }
@@ -1245,14 +1314,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 651
+                      "offset": 721
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 17,
-                      "offset": 663
+                      "offset": 733
                     },
                     "indent": []
                   }
@@ -1260,14 +1329,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 651
+                  "offset": 721
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 17,
-                  "offset": 663
+                  "offset": 733
                 },
                 "indent": []
               }
@@ -1275,14 +1344,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 647
+              "offset": 717
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 17,
-              "offset": 663
+              "offset": 733
             },
             "indent": []
           }
@@ -1305,14 +1374,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 669
+                          "offset": 739
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 672
+                          "offset": 742
                         },
                         "indent": []
                       }
@@ -1320,14 +1389,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 668
+                      "offset": 738
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 10,
-                      "offset": 673
+                      "offset": 743
                     },
                     "indent": []
                   }
@@ -1335,14 +1404,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 668
+                  "offset": 738
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 10,
-                  "offset": 673
+                  "offset": 743
                 },
                 "indent": []
               }
@@ -1350,14 +1419,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 664
+              "offset": 734
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 10,
-              "offset": 673
+              "offset": 743
             },
             "indent": []
           }
@@ -1380,14 +1449,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 679
+                          "offset": 749
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 7,
-                          "offset": 680
+                          "offset": 750
                         },
                         "indent": []
                       }
@@ -1397,14 +1466,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 7,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 682
+                          "offset": 752
                         },
                         "indent": []
                       }
@@ -1414,14 +1483,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 682
+                          "offset": 752
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 10,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1429,14 +1498,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 678
+                      "offset": 748
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 11,
-                      "offset": 684
+                      "offset": 754
                     },
                     "indent": []
                   }
@@ -1444,14 +1513,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 678
+                  "offset": 748
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 11,
-                  "offset": 684
+                  "offset": 754
                 },
                 "indent": []
               }
@@ -1459,14 +1528,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 674
+              "offset": 744
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 11,
-              "offset": 684
+              "offset": 754
             },
             "indent": []
           }
@@ -1489,14 +1558,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 690
+                          "offset": 760
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 691
+                          "offset": 761
                         },
                         "indent": []
                       }
@@ -1506,14 +1575,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 691
+                          "offset": 761
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 693
+                          "offset": 763
                         },
                         "indent": []
                       }
@@ -1523,14 +1592,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 693
+                          "offset": 763
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 11,
-                          "offset": 695
+                          "offset": 765
                         },
                         "indent": []
                       }
@@ -1538,14 +1607,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 689
+                      "offset": 759
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 12,
-                      "offset": 696
+                      "offset": 766
                     },
                     "indent": []
                   }
@@ -1553,14 +1622,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 689
+                  "offset": 759
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 12,
-                  "offset": 696
+                  "offset": 766
                 },
                 "indent": []
               }
@@ -1568,14 +1637,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 685
+              "offset": 755
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 12,
-              "offset": 696
+              "offset": 766
             },
             "indent": []
           }
@@ -1598,14 +1667,14 @@
                       "value": "a_a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 702
+                          "offset": 772
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 705
+                          "offset": 775
                         },
                         "indent": []
                       }
@@ -1615,14 +1684,14 @@
                       "value": "_",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 705
+                          "offset": 775
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 707
+                          "offset": 777
                         },
                         "indent": []
                       }
@@ -1632,14 +1701,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 12,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1647,14 +1716,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 701
+                      "offset": 771
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 13,
-                      "offset": 709
+                      "offset": 779
                     },
                     "indent": []
                   }
@@ -1662,14 +1731,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 701
+                  "offset": 771
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 13,
-                  "offset": 709
+                  "offset": 779
                 },
                 "indent": []
               }
@@ -1677,14 +1746,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 697
+              "offset": 767
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 13,
-              "offset": 709
+              "offset": 779
             },
             "indent": []
           }
@@ -1692,14 +1761,14 @@
       ],
       "position": {
         "start": {
-          "line": 35,
+          "line": 37,
           "column": 1,
-          "offset": 631
+          "offset": 701
         },
         "end": {
-          "line": 40,
+          "line": 42,
           "column": 13,
-          "offset": 709
+          "offset": 779
         },
         "indent": [
           1,
@@ -1721,14 +1790,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 42,
+                  "line": 44,
                   "column": 3,
-                  "offset": 713
+                  "offset": 783
                 },
                 "end": {
-                  "line": 42,
+                  "line": 44,
                   "column": 7,
-                  "offset": 717
+                  "offset": 787
                 },
                 "indent": []
               }
@@ -1736,14 +1805,14 @@
           ],
           "position": {
             "start": {
-              "line": 42,
+              "line": 44,
               "column": 1,
-              "offset": 711
+              "offset": 781
             },
             "end": {
-              "line": 42,
+              "line": 44,
               "column": 9,
-              "offset": 719
+              "offset": 789
             },
             "indent": []
           }
@@ -1751,14 +1820,14 @@
       ],
       "position": {
         "start": {
-          "line": 42,
+          "line": 44,
           "column": 1,
-          "offset": 711
+          "offset": 781
         },
         "end": {
-          "line": 42,
+          "line": 44,
           "column": 9,
-          "offset": 719
+          "offset": 789
         },
         "indent": []
       }
@@ -1771,14 +1840,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 44,
+              "line": 46,
               "column": 1,
-              "offset": 721
+              "offset": 791
             },
             "end": {
-              "line": 44,
+              "line": 46,
               "column": 33,
-              "offset": 753
+              "offset": 823
             },
             "indent": []
           }
@@ -1786,14 +1855,14 @@
       ],
       "position": {
         "start": {
-          "line": 44,
+          "line": 46,
           "column": 1,
-          "offset": 721
+          "offset": 791
         },
         "end": {
-          "line": 44,
+          "line": 46,
           "column": 33,
-          "offset": 753
+          "offset": 823
         },
         "indent": []
       }
@@ -1817,14 +1886,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 46,
+                      "line": 48,
                       "column": 5,
-                      "offset": 759
+                      "offset": 829
                     },
                     "end": {
-                      "line": 46,
+                      "line": 48,
                       "column": 9,
-                      "offset": 763
+                      "offset": 833
                     },
                     "indent": []
                   }
@@ -1834,14 +1903,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 46,
+                      "line": 48,
                       "column": 9,
-                      "offset": 763
+                      "offset": 833
                     },
                     "end": {
-                      "line": 46,
+                      "line": 48,
                       "column": 15,
-                      "offset": 769
+                      "offset": 839
                     },
                     "indent": []
                   }
@@ -1851,14 +1920,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 46,
+                      "line": 48,
                       "column": 15,
-                      "offset": 769
+                      "offset": 839
                     },
                     "end": {
-                      "line": 46,
+                      "line": 48,
                       "column": 64,
-                      "offset": 818
+                      "offset": 888
                     },
                     "indent": []
                   }
@@ -1866,14 +1935,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 46,
+                  "line": 48,
                   "column": 5,
-                  "offset": 759
+                  "offset": 829
                 },
                 "end": {
-                  "line": 46,
+                  "line": 48,
                   "column": 64,
-                  "offset": 818
+                  "offset": 888
                 },
                 "indent": []
               }
@@ -1881,14 +1950,14 @@
           ],
           "position": {
             "start": {
-              "line": 46,
+              "line": 48,
               "column": 1,
-              "offset": 755
+              "offset": 825
             },
             "end": {
-              "line": 46,
+              "line": 48,
               "column": 64,
-              "offset": 818
+              "offset": 888
             },
             "indent": []
           }
@@ -1906,14 +1975,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 823
+                      "offset": 893
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 10,
-                      "offset": 828
+                      "offset": 898
                     },
                     "indent": []
                   }
@@ -1923,14 +1992,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 10,
-                      "offset": 828
+                      "offset": 898
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 16,
-                      "offset": 834
+                      "offset": 904
                     },
                     "indent": []
                   }
@@ -1940,14 +2009,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 16,
-                      "offset": 834
+                      "offset": 904
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 65,
-                      "offset": 883
+                      "offset": 953
                     },
                     "indent": []
                   }
@@ -1955,14 +2024,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 823
+                  "offset": 893
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 65,
-                  "offset": 883
+                  "offset": 953
                 },
                 "indent": []
               }
@@ -1970,14 +2039,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 819
+              "offset": 889
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 65,
-              "offset": 883
+              "offset": 953
             },
             "indent": []
           }
@@ -1985,14 +2054,14 @@
       ],
       "position": {
         "start": {
-          "line": 46,
+          "line": 48,
           "column": 1,
-          "offset": 755
+          "offset": 825
         },
         "end": {
-          "line": 47,
+          "line": 49,
           "column": 65,
-          "offset": 883
+          "offset": 953
         },
         "indent": [
           1
@@ -2007,14 +2076,14 @@
           "value": "Double tildes should be ",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 885
+              "offset": 955
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 25,
-              "offset": 909
+              "offset": 979
             },
             "indent": []
           }
@@ -2024,14 +2093,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 25,
-              "offset": 909
+              "offset": 979
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 27,
-              "offset": 911
+              "offset": 981
             },
             "indent": []
           }
@@ -2041,14 +2110,14 @@
           "value": "~escaped",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 27,
-              "offset": 911
+              "offset": 981
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 35,
-              "offset": 919
+              "offset": 989
             },
             "indent": []
           }
@@ -2058,14 +2127,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 35,
-              "offset": 919
+              "offset": 989
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 37,
-              "offset": 921
+              "offset": 991
             },
             "indent": []
           }
@@ -2075,14 +2144,14 @@
           "value": "~.\nAnd here: foo",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 37,
-              "offset": 921
+              "offset": 991
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 14,
-              "offset": 937
+              "offset": 1007
             },
             "indent": [
               1
@@ -2094,14 +2163,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 14,
-              "offset": 937
+              "offset": 1007
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 16,
-              "offset": 939
+              "offset": 1009
             },
             "indent": []
           }
@@ -2111,14 +2180,14 @@
           "value": "~.",
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 16,
-              "offset": 939
+              "offset": 1009
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 18,
-              "offset": 941
+              "offset": 1011
             },
             "indent": []
           }
@@ -2126,14 +2195,14 @@
       ],
       "position": {
         "start": {
-          "line": 49,
+          "line": 51,
           "column": 1,
-          "offset": 885
+          "offset": 955
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 18,
-          "offset": 941
+          "offset": 1011
         },
         "indent": [
           1
@@ -2148,14 +2217,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 943
+              "offset": 1013
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 36,
-              "offset": 978
+              "offset": 1048
             },
             "indent": []
           }
@@ -2163,14 +2232,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 943
+          "offset": 1013
         },
         "end": {
-          "line": 52,
+          "line": 54,
           "column": 36,
-          "offset": 978
+          "offset": 1048
         },
         "indent": []
       }
@@ -2193,14 +2262,14 @@
                   "value": "here",
                   "position": {
                     "start": {
-                      "line": 54,
+                      "line": 56,
                       "column": 3,
-                      "offset": 982
+                      "offset": 1052
                     },
                     "end": {
-                      "line": 54,
+                      "line": 56,
                       "column": 7,
-                      "offset": 986
+                      "offset": 1056
                     },
                     "indent": []
                   }
@@ -2208,14 +2277,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 54,
+                  "line": 56,
                   "column": 3,
-                  "offset": 982
+                  "offset": 1052
                 },
                 "end": {
-                  "line": 54,
+                  "line": 56,
                   "column": 9,
-                  "offset": 988
+                  "offset": 1058
                 },
                 "indent": []
               }
@@ -2228,14 +2297,14 @@
                   "value": "they",
                   "position": {
                     "start": {
-                      "line": 54,
+                      "line": 56,
                       "column": 12,
-                      "offset": 991
+                      "offset": 1061
                     },
                     "end": {
-                      "line": 54,
+                      "line": 56,
                       "column": 16,
-                      "offset": 995
+                      "offset": 1065
                     },
                     "indent": []
                   }
@@ -2243,14 +2312,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 54,
+                  "line": 56,
                   "column": 12,
-                  "offset": 991
+                  "offset": 1061
                 },
                 "end": {
-                  "line": 54,
+                  "line": 56,
                   "column": 20,
-                  "offset": 999
+                  "offset": 1069
                 },
                 "indent": []
               }
@@ -2258,14 +2327,14 @@
           ],
           "position": {
             "start": {
-              "line": 54,
+              "line": 56,
               "column": 1,
-              "offset": 980
+              "offset": 1050
             },
             "end": {
-              "line": 54,
+              "line": 56,
               "column": 22,
-              "offset": 1001
+              "offset": 1071
             },
             "indent": []
           }
@@ -2281,14 +2350,14 @@
                   "value": "should",
                   "position": {
                     "start": {
-                      "line": 56,
+                      "line": 58,
                       "column": 3,
-                      "offset": 1026
+                      "offset": 1096
                     },
                     "end": {
-                      "line": 56,
+                      "line": 58,
                       "column": 9,
-                      "offset": 1032
+                      "offset": 1102
                     },
                     "indent": []
                   }
@@ -2296,14 +2365,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 56,
+                  "line": 58,
                   "column": 3,
-                  "offset": 1026
+                  "offset": 1096
                 },
                 "end": {
-                  "line": 56,
+                  "line": 58,
                   "column": 9,
-                  "offset": 1032
+                  "offset": 1102
                 },
                 "indent": []
               }
@@ -2316,14 +2385,14 @@
                   "value": "tho",
                   "position": {
                     "start": {
-                      "line": 56,
+                      "line": 58,
                       "column": 12,
-                      "offset": 1035
+                      "offset": 1105
                     },
                     "end": {
-                      "line": 56,
+                      "line": 58,
                       "column": 15,
-                      "offset": 1038
+                      "offset": 1108
                     },
                     "indent": []
                   }
@@ -2333,14 +2402,14 @@
                   "value": "|",
                   "position": {
                     "start": {
-                      "line": 56,
+                      "line": 58,
                       "column": 15,
-                      "offset": 1038
+                      "offset": 1108
                     },
                     "end": {
-                      "line": 56,
+                      "line": 58,
                       "column": 17,
-                      "offset": 1040
+                      "offset": 1110
                     },
                     "indent": []
                   }
@@ -2350,14 +2419,14 @@
                   "value": "ugh",
                   "position": {
                     "start": {
-                      "line": 56,
+                      "line": 58,
                       "column": 17,
-                      "offset": 1040
+                      "offset": 1110
                     },
                     "end": {
-                      "line": 56,
+                      "line": 58,
                       "column": 20,
-                      "offset": 1043
+                      "offset": 1113
                     },
                     "indent": []
                   }
@@ -2365,14 +2434,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 56,
+                  "line": 58,
                   "column": 12,
-                  "offset": 1035
+                  "offset": 1105
                 },
                 "end": {
-                  "line": 56,
+                  "line": 58,
                   "column": 20,
-                  "offset": 1043
+                  "offset": 1113
                 },
                 "indent": []
               }
@@ -2380,14 +2449,14 @@
           ],
           "position": {
             "start": {
-              "line": 56,
+              "line": 58,
               "column": 1,
-              "offset": 1024
+              "offset": 1094
             },
             "end": {
-              "line": 56,
+              "line": 58,
               "column": 22,
-              "offset": 1045
+              "offset": 1115
             },
             "indent": []
           }
@@ -2395,14 +2464,14 @@
       ],
       "position": {
         "start": {
-          "line": 54,
+          "line": 56,
           "column": 1,
-          "offset": 980
+          "offset": 1050
         },
         "end": {
-          "line": 56,
+          "line": 58,
           "column": 22,
-          "offset": 1045
+          "offset": 1115
         },
         "indent": [
           1,
@@ -2418,14 +2487,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 58,
+              "line": 60,
               "column": 1,
-              "offset": 1047
+              "offset": 1117
             },
             "end": {
-              "line": 58,
+              "line": 60,
               "column": 10,
-              "offset": 1056
+              "offset": 1126
             },
             "indent": []
           }
@@ -2433,14 +2502,14 @@
       ],
       "position": {
         "start": {
-          "line": 58,
+          "line": 60,
           "column": 1,
-          "offset": 1047
+          "offset": 1117
         },
         "end": {
-          "line": 58,
+          "line": 60,
           "column": 10,
-          "offset": 1056
+          "offset": 1126
         },
         "indent": []
       }
@@ -2453,14 +2522,14 @@
           "value": "| here   | they   |\n",
           "position": {
             "start": {
-              "line": 60,
+              "line": 62,
               "column": 1,
-              "offset": 1058
+              "offset": 1128
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1078
+              "offset": 1148
             },
             "indent": [
               1
@@ -2472,14 +2541,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1078
+              "offset": 1148
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 3,
-              "offset": 1080
+              "offset": 1150
             },
             "indent": []
           }
@@ -2489,14 +2558,14 @@
           "value": " ---- ",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 3,
-              "offset": 1080
+              "offset": 1150
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 9,
-              "offset": 1086
+              "offset": 1156
             },
             "indent": []
           }
@@ -2506,14 +2575,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 9,
-              "offset": 1086
+              "offset": 1156
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 11,
-              "offset": 1088
+              "offset": 1158
             },
             "indent": []
           }
@@ -2523,14 +2592,14 @@
           "value": " ----- ",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 11,
-              "offset": 1088
+              "offset": 1158
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 18,
-              "offset": 1095
+              "offset": 1165
             },
             "indent": []
           }
@@ -2540,14 +2609,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 18,
-              "offset": 1095
+              "offset": 1165
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 20,
-              "offset": 1097
+              "offset": 1167
             },
             "indent": []
           }
@@ -2557,14 +2626,14 @@
           "value": "\n| should | though |",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 20,
-              "offset": 1097
+              "offset": 1167
             },
             "end": {
-              "line": 62,
+              "line": 64,
               "column": 20,
-              "offset": 1117
+              "offset": 1187
             },
             "indent": [
               1
@@ -2574,14 +2643,14 @@
       ],
       "position": {
         "start": {
-          "line": 60,
+          "line": 62,
           "column": 1,
-          "offset": 1058
+          "offset": 1128
         },
         "end": {
-          "line": 62,
+          "line": 64,
           "column": 20,
-          "offset": 1117
+          "offset": 1187
         },
         "indent": [
           1,
@@ -2597,14 +2666,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1119
+              "offset": 1189
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 10,
-              "offset": 1128
+              "offset": 1198
             },
             "indent": []
           }
@@ -2612,14 +2681,14 @@
       ],
       "position": {
         "start": {
-          "line": 64,
+          "line": 66,
           "column": 1,
-          "offset": 1119
+          "offset": 1189
         },
         "end": {
-          "line": 64,
+          "line": 66,
           "column": 10,
-          "offset": 1128
+          "offset": 1198
         },
         "indent": []
       }
@@ -2632,14 +2701,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 66,
+              "line": 68,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1144
+              "offset": 1214
             },
             "indent": [
               1
@@ -2651,14 +2720,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1144
+              "offset": 1214
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 3,
-              "offset": 1146
+              "offset": 1216
             },
             "indent": []
           }
@@ -2668,14 +2737,14 @@
           "value": "--- ",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 3,
-              "offset": 1146
+              "offset": 1216
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 7,
-              "offset": 1150
+              "offset": 1220
             },
             "indent": []
           }
@@ -2685,14 +2754,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 7,
-              "offset": 1150
+              "offset": 1220
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 9,
-              "offset": 1152
+              "offset": 1222
             },
             "indent": []
           }
@@ -2702,14 +2771,14 @@
           "value": " ------\nshould | though",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 9,
-              "offset": 1152
+              "offset": 1222
             },
             "end": {
-              "line": 68,
+              "line": 70,
               "column": 16,
-              "offset": 1175
+              "offset": 1245
             },
             "indent": [
               1
@@ -2719,14 +2788,14 @@
       ],
       "position": {
         "start": {
-          "line": 66,
+          "line": 68,
           "column": 1,
-          "offset": 1130
+          "offset": 1200
         },
         "end": {
-          "line": 68,
+          "line": 70,
           "column": 16,
-          "offset": 1175
+          "offset": 1245
         },
         "indent": [
           1,
@@ -2745,14 +2814,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 70,
+                  "line": 72,
                   "column": 3,
-                  "offset": 1179
+                  "offset": 1249
                 },
                 "end": {
-                  "line": 70,
+                  "line": 72,
                   "column": 14,
-                  "offset": 1190
+                  "offset": 1260
                 },
                 "indent": []
               }
@@ -2760,14 +2829,14 @@
           ],
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1177
+              "offset": 1247
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 16,
-              "offset": 1192
+              "offset": 1262
             },
             "indent": []
           }
@@ -2775,14 +2844,14 @@
       ],
       "position": {
         "start": {
-          "line": 70,
+          "line": 72,
           "column": 1,
-          "offset": 1177
+          "offset": 1247
         },
         "end": {
-          "line": 70,
+          "line": 72,
           "column": 16,
-          "offset": 1192
+          "offset": 1262
         },
         "indent": []
       }
@@ -2795,14 +2864,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 72,
+              "line": 74,
               "column": 1,
-              "offset": 1194
+              "offset": 1264
             },
             "end": {
-              "line": 72,
+              "line": 74,
               "column": 38,
-              "offset": 1231
+              "offset": 1301
             },
             "indent": []
           }
@@ -2810,14 +2879,14 @@
       ],
       "position": {
         "start": {
-          "line": 72,
+          "line": 74,
           "column": 1,
-          "offset": 1194
+          "offset": 1264
         },
         "end": {
-          "line": 72,
+          "line": 74,
           "column": 38,
-          "offset": 1231
+          "offset": 1301
         },
         "indent": []
       }
@@ -2841,14 +2910,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 5,
-                      "offset": 1237
+                      "offset": 1307
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 9,
-                      "offset": 1241
+                      "offset": 1311
                     },
                     "indent": []
                   }
@@ -2858,14 +2927,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 9,
-                      "offset": 1241
+                      "offset": 1311
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 13,
-                      "offset": 1245
+                      "offset": 1315
                     },
                     "indent": []
                   }
@@ -2875,14 +2944,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 13,
-                      "offset": 1245
+                      "offset": 1315
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 17,
-                      "offset": 1249
+                      "offset": 1319
                     },
                     "indent": []
                   }
@@ -2892,14 +2961,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 17,
-                      "offset": 1249
+                      "offset": 1319
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 22,
-                      "offset": 1254
+                      "offset": 1324
                     },
                     "indent": []
                   }
@@ -2907,14 +2976,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 74,
+                  "line": 76,
                   "column": 5,
-                  "offset": 1237
+                  "offset": 1307
                 },
                 "end": {
-                  "line": 74,
+                  "line": 76,
                   "column": 22,
-                  "offset": 1254
+                  "offset": 1324
                 },
                 "indent": []
               }
@@ -2922,14 +2991,14 @@
           ],
           "position": {
             "start": {
-              "line": 74,
+              "line": 76,
               "column": 1,
-              "offset": 1233
+              "offset": 1303
             },
             "end": {
-              "line": 74,
+              "line": 76,
               "column": 22,
-              "offset": 1254
+              "offset": 1324
             },
             "indent": []
           }
@@ -2947,14 +3016,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 5,
-                      "offset": 1259
+                      "offset": 1329
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 9,
-                      "offset": 1263
+                      "offset": 1333
                     },
                     "indent": []
                   }
@@ -2964,14 +3033,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 9,
-                      "offset": 1263
+                      "offset": 1333
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 13,
-                      "offset": 1267
+                      "offset": 1337
                     },
                     "indent": []
                   }
@@ -2981,14 +3050,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 13,
-                      "offset": 1267
+                      "offset": 1337
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 19,
-                      "offset": 1273
+                      "offset": 1343
                     },
                     "indent": []
                   }
@@ -2998,14 +3067,14 @@
                   "value": "google.com>",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 19,
-                      "offset": 1273
+                      "offset": 1343
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 30,
-                      "offset": 1284
+                      "offset": 1354
                     },
                     "indent": []
                   }
@@ -3013,14 +3082,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 75,
+                  "line": 77,
                   "column": 5,
-                  "offset": 1259
+                  "offset": 1329
                 },
                 "end": {
-                  "line": 75,
+                  "line": 77,
                   "column": 30,
-                  "offset": 1284
+                  "offset": 1354
                 },
                 "indent": []
               }
@@ -3028,14 +3097,14 @@
           ],
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1255
+              "offset": 1325
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 30,
-              "offset": 1284
+              "offset": 1354
             },
             "indent": []
           }
@@ -3043,14 +3112,14 @@
       ],
       "position": {
         "start": {
-          "line": 74,
+          "line": 76,
           "column": 1,
-          "offset": 1233
+          "offset": 1303
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 30,
-          "offset": 1284
+          "offset": 1354
         },
         "indent": [
           1
@@ -3065,9 +3134,9 @@
       "offset": 0
     },
     "end": {
-      "line": 76,
+      "line": 78,
       "column": 1,
-      "offset": 1285
+      "offset": 1355
     }
   }
 }

--- a/test/tree/stringify-escape.output.nogfm.commonmark.nogfm.commonmark.json
+++ b/test/tree/stringify-escape.output.nogfm.commonmark.nogfm.commonmark.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,115 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in_the_middle_of_a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +354,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +369,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +400,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "indent": []
                   }
@@ -348,14 +417,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 7,
-                      "offset": 195
+                      "offset": 265
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "indent": []
                   }
@@ -365,14 +434,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 15,
-                      "offset": 203
+                      "offset": 273
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "indent": []
                   }
@@ -382,14 +451,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 17,
-                      "offset": 205
+                      "offset": 275
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "indent": []
                   }
@@ -399,14 +468,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 22,
-                      "offset": 210
+                      "offset": 280
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "indent": []
                   }
@@ -416,14 +485,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 24,
-                      "offset": 212
+                      "offset": 282
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +515,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +540,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 16,
-                      "offset": 232
+                      "offset": 302
                     },
                     "indent": []
                   }
@@ -488,14 +557,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 16,
-                      "offset": 232
+                      "offset": 302
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 27,
-                      "offset": 243
+                      "offset": 313
                     },
                     "indent": []
                   }
@@ -505,14 +574,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 27,
-                      "offset": 243
+                      "offset": 313
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 43,
-                      "offset": 259
+                      "offset": 329
                     },
                     "indent": []
                   }
@@ -520,14 +589,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 43,
-                  "offset": 259
+                  "offset": 329
                 },
                 "indent": []
               }
@@ -535,14 +604,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 43,
-              "offset": 259
+              "offset": 329
             },
             "indent": []
           }
@@ -550,14 +619,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 12,
+          "line": 14,
           "column": 43,
-          "offset": 259
+          "offset": 329
         },
         "indent": [
           1
@@ -572,14 +641,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 14,
+              "line": 16,
               "column": 1,
-              "offset": 261
+              "offset": 331
             },
             "end": {
-              "line": 14,
+              "line": 16,
               "column": 63,
-              "offset": 323
+              "offset": 393
             },
             "indent": []
           }
@@ -587,14 +656,14 @@
       ],
       "position": {
         "start": {
-          "line": 14,
+          "line": 16,
           "column": 1,
-          "offset": 261
+          "offset": 331
         },
         "end": {
-          "line": 14,
+          "line": 16,
           "column": 63,
-          "offset": 323
+          "offset": 393
         },
         "indent": []
       }
@@ -612,14 +681,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 16,
+                  "line": 18,
                   "column": 2,
-                  "offset": 326
+                  "offset": 396
                 },
                 "end": {
-                  "line": 16,
+                  "line": 18,
                   "column": 5,
-                  "offset": 329
+                  "offset": 399
                 },
                 "indent": []
               }
@@ -627,14 +696,14 @@
           ],
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 1,
-              "offset": 325
+              "offset": 395
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 6,
-              "offset": 330
+              "offset": 400
             },
             "indent": []
           }
@@ -644,14 +713,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 6,
-              "offset": 330
+              "offset": 400
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 8,
-              "offset": 332
+              "offset": 402
             },
             "indent": []
           }
@@ -661,14 +730,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 8,
-              "offset": 332
+              "offset": 402
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 13,
-              "offset": 337
+              "offset": 407
             },
             "indent": []
           }
@@ -676,14 +745,14 @@
       ],
       "position": {
         "start": {
-          "line": 16,
+          "line": 18,
           "column": 1,
-          "offset": 325
+          "offset": 395
         },
         "end": {
-          "line": 16,
+          "line": 18,
           "column": 13,
-          "offset": 337
+          "offset": 407
         },
         "indent": []
       }
@@ -696,14 +765,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 18,
+              "line": 20,
               "column": 1,
-              "offset": 339
+              "offset": 409
             },
             "end": {
-              "line": 18,
+              "line": 20,
               "column": 53,
-              "offset": 391
+              "offset": 461
             },
             "indent": []
           }
@@ -711,14 +780,14 @@
       ],
       "position": {
         "start": {
-          "line": 18,
+          "line": 20,
           "column": 1,
-          "offset": 339
+          "offset": 409
         },
         "end": {
-          "line": 18,
+          "line": 20,
           "column": 53,
-          "offset": 391
+          "offset": 461
         },
         "indent": []
       }
@@ -731,14 +800,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 20,
+              "line": 22,
               "column": 1,
-              "offset": 393
+              "offset": 463
             },
             "end": {
-              "line": 20,
+              "line": 22,
               "column": 3,
-              "offset": 395
+              "offset": 465
             },
             "indent": []
           }
@@ -748,14 +817,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 20,
+              "line": 22,
               "column": 3,
-              "offset": 395
+              "offset": 465
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 412
+              "offset": 482
             },
             "indent": [
               1
@@ -767,14 +836,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 412
+              "offset": 482
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 414
+              "offset": 484
             },
             "indent": []
           }
@@ -784,14 +853,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 414
+              "offset": 484
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 433
+              "offset": 503
             },
             "indent": [
               1
@@ -803,14 +872,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 433
+              "offset": 503
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 5,
-              "offset": 435
+              "offset": 505
             },
             "indent": []
           }
@@ -820,14 +889,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 5,
-              "offset": 435
+              "offset": 505
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 21,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -835,14 +904,14 @@
       ],
       "position": {
         "start": {
-          "line": 20,
+          "line": 22,
           "column": 1,
-          "offset": 393
+          "offset": 463
         },
         "end": {
-          "line": 22,
+          "line": 24,
           "column": 21,
-          "offset": 451
+          "offset": 521
         },
         "indent": [
           1,
@@ -858,14 +927,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 24,
+              "line": 26,
               "column": 1,
-              "offset": 453
+              "offset": 523
             },
             "end": {
-              "line": 24,
+              "line": 26,
               "column": 25,
-              "offset": 477
+              "offset": 547
             },
             "indent": []
           }
@@ -873,14 +942,14 @@
       ],
       "position": {
         "start": {
-          "line": 24,
+          "line": 26,
           "column": 1,
-          "offset": 453
+          "offset": 523
         },
         "end": {
-          "line": 24,
+          "line": 26,
           "column": 25,
-          "offset": 477
+          "offset": 547
         },
         "indent": []
       }
@@ -893,14 +962,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 1,
-              "offset": 479
+              "offset": 549
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 3,
-              "offset": 481
+              "offset": 551
             },
             "indent": []
           }
@@ -910,14 +979,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 3,
-              "offset": 481
+              "offset": 551
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 21,
-              "offset": 499
+              "offset": 569
             },
             "indent": []
           }
@@ -925,14 +994,14 @@
       ],
       "position": {
         "start": {
-          "line": 26,
+          "line": 28,
           "column": 1,
-          "offset": 479
+          "offset": 549
         },
         "end": {
-          "line": 26,
+          "line": 28,
           "column": 21,
-          "offset": 499
+          "offset": 569
         },
         "indent": []
       }
@@ -945,14 +1014,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 28,
+              "line": 30,
               "column": 1,
-              "offset": 501
+              "offset": 571
             },
             "end": {
-              "line": 28,
+              "line": 30,
               "column": 16,
-              "offset": 516
+              "offset": 586
             },
             "indent": []
           }
@@ -960,14 +1029,14 @@
       ],
       "position": {
         "start": {
-          "line": 28,
+          "line": 30,
           "column": 1,
-          "offset": 501
+          "offset": 571
         },
         "end": {
-          "line": 28,
+          "line": 30,
           "column": 16,
-          "offset": 516
+          "offset": 586
         },
         "indent": []
       }
@@ -980,14 +1049,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 1,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 30,
+              "line": 32,
               "column": 3,
-              "offset": 520
+              "offset": 590
             },
             "indent": []
           }
@@ -997,14 +1066,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 3,
-              "offset": 520
+              "offset": 590
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 537
+              "offset": 607
             },
             "indent": [
               1
@@ -1016,14 +1085,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 537
+              "offset": 607
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 5,
-              "offset": 539
+              "offset": 609
             },
             "indent": []
           }
@@ -1033,14 +1102,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 5,
-              "offset": 539
+              "offset": 609
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 23,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1048,14 +1117,14 @@
       ],
       "position": {
         "start": {
-          "line": 30,
+          "line": 32,
           "column": 1,
-          "offset": 518
+          "offset": 588
         },
         "end": {
-          "line": 31,
+          "line": 33,
           "column": 23,
-          "offset": 557
+          "offset": 627
         },
         "indent": [
           1
@@ -1070,14 +1139,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 33,
+              "line": 35,
               "column": 1,
-              "offset": 559
+              "offset": 629
             },
             "end": {
-              "line": 33,
+              "line": 35,
               "column": 62,
-              "offset": 620
+              "offset": 690
             },
             "indent": []
           }
@@ -1085,14 +1154,14 @@
       ],
       "position": {
         "start": {
-          "line": 33,
+          "line": 35,
           "column": 1,
-          "offset": 559
+          "offset": 629
         },
         "end": {
-          "line": 33,
+          "line": 35,
           "column": 62,
-          "offset": 620
+          "offset": 690
         },
         "indent": []
       }
@@ -1121,14 +1190,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 35,
+                          "line": 37,
                           "column": 6,
-                          "offset": 627
+                          "offset": 697
                         },
                         "end": {
-                          "line": 35,
+                          "line": 37,
                           "column": 15,
-                          "offset": 636
+                          "offset": 706
                         },
                         "indent": []
                       }
@@ -1136,14 +1205,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 35,
+                      "line": 37,
                       "column": 5,
-                      "offset": 626
+                      "offset": 696
                     },
                     "end": {
-                      "line": 35,
+                      "line": 37,
                       "column": 16,
-                      "offset": 637
+                      "offset": 707
                     },
                     "indent": []
                   }
@@ -1151,14 +1220,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 35,
+                  "line": 37,
                   "column": 5,
-                  "offset": 626
+                  "offset": 696
                 },
                 "end": {
-                  "line": 35,
+                  "line": 37,
                   "column": 16,
-                  "offset": 637
+                  "offset": 707
                 },
                 "indent": []
               }
@@ -1166,14 +1235,14 @@
           ],
           "position": {
             "start": {
-              "line": 35,
+              "line": 37,
               "column": 1,
-              "offset": 622
+              "offset": 692
             },
             "end": {
-              "line": 35,
+              "line": 37,
               "column": 16,
-              "offset": 637
+              "offset": 707
             },
             "indent": []
           }
@@ -1196,14 +1265,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 643
+                          "offset": 713
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 9,
-                          "offset": 646
+                          "offset": 716
                         },
                         "indent": []
                       }
@@ -1213,14 +1282,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 9,
-                          "offset": 646
+                          "offset": 716
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 11,
-                          "offset": 648
+                          "offset": 718
                         },
                         "indent": []
                       }
@@ -1230,14 +1299,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 11,
-                          "offset": 648
+                          "offset": 718
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 16,
-                          "offset": 653
+                          "offset": 723
                         },
                         "indent": []
                       }
@@ -1245,14 +1314,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 642
+                      "offset": 712
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 17,
-                      "offset": 654
+                      "offset": 724
                     },
                     "indent": []
                   }
@@ -1260,14 +1329,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 642
+                  "offset": 712
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 17,
-                  "offset": 654
+                  "offset": 724
                 },
                 "indent": []
               }
@@ -1275,14 +1344,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 638
+              "offset": 708
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 17,
-              "offset": 654
+              "offset": 724
             },
             "indent": []
           }
@@ -1305,14 +1374,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 660
+                          "offset": 730
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 663
+                          "offset": 733
                         },
                         "indent": []
                       }
@@ -1320,14 +1389,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 659
+                      "offset": 729
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 10,
-                      "offset": 664
+                      "offset": 734
                     },
                     "indent": []
                   }
@@ -1335,14 +1404,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 659
+                  "offset": 729
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 10,
-                  "offset": 664
+                  "offset": 734
                 },
                 "indent": []
               }
@@ -1350,14 +1419,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 655
+              "offset": 725
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 10,
-              "offset": 664
+              "offset": 734
             },
             "indent": []
           }
@@ -1380,14 +1449,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 670
+                          "offset": 740
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 7,
-                          "offset": 671
+                          "offset": 741
                         },
                         "indent": []
                       }
@@ -1397,14 +1466,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 7,
-                          "offset": 671
+                          "offset": 741
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1414,14 +1483,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 673
+                          "offset": 743
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 10,
-                          "offset": 674
+                          "offset": 744
                         },
                         "indent": []
                       }
@@ -1429,14 +1498,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 669
+                      "offset": 739
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 11,
-                      "offset": 675
+                      "offset": 745
                     },
                     "indent": []
                   }
@@ -1444,14 +1513,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 669
+                  "offset": 739
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 11,
-                  "offset": 675
+                  "offset": 745
                 },
                 "indent": []
               }
@@ -1459,14 +1528,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 665
+              "offset": 735
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 11,
-              "offset": 675
+              "offset": 745
             },
             "indent": []
           }
@@ -1489,14 +1558,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 681
+                          "offset": 751
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 682
+                          "offset": 752
                         },
                         "indent": []
                       }
@@ -1506,14 +1575,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 682
+                          "offset": 752
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 684
+                          "offset": 754
                         },
                         "indent": []
                       }
@@ -1523,14 +1592,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 684
+                          "offset": 754
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 11,
-                          "offset": 686
+                          "offset": 756
                         },
                         "indent": []
                       }
@@ -1538,14 +1607,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 680
+                      "offset": 750
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 12,
-                      "offset": 687
+                      "offset": 757
                     },
                     "indent": []
                   }
@@ -1553,14 +1622,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 680
+                  "offset": 750
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 12,
-                  "offset": 687
+                  "offset": 757
                 },
                 "indent": []
               }
@@ -1568,14 +1637,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 676
+              "offset": 746
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 12,
-              "offset": 687
+              "offset": 757
             },
             "indent": []
           }
@@ -1598,14 +1667,14 @@
                       "value": "a_a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 693
+                          "offset": 763
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 696
+                          "offset": 766
                         },
                         "indent": []
                       }
@@ -1615,14 +1684,14 @@
                       "value": "_",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 696
+                          "offset": 766
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 698
+                          "offset": 768
                         },
                         "indent": []
                       }
@@ -1632,14 +1701,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 698
+                          "offset": 768
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 12,
-                          "offset": 699
+                          "offset": 769
                         },
                         "indent": []
                       }
@@ -1647,14 +1716,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 692
+                      "offset": 762
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 13,
-                      "offset": 700
+                      "offset": 770
                     },
                     "indent": []
                   }
@@ -1662,14 +1731,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 692
+                  "offset": 762
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 13,
-                  "offset": 700
+                  "offset": 770
                 },
                 "indent": []
               }
@@ -1677,14 +1746,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 688
+              "offset": 758
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 13,
-              "offset": 700
+              "offset": 770
             },
             "indent": []
           }
@@ -1692,14 +1761,14 @@
       ],
       "position": {
         "start": {
-          "line": 35,
+          "line": 37,
           "column": 1,
-          "offset": 622
+          "offset": 692
         },
         "end": {
-          "line": 40,
+          "line": 42,
           "column": 13,
-          "offset": 700
+          "offset": 770
         },
         "indent": [
           1,
@@ -1721,14 +1790,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 42,
+                  "line": 44,
                   "column": 3,
-                  "offset": 704
+                  "offset": 774
                 },
                 "end": {
-                  "line": 42,
+                  "line": 44,
                   "column": 7,
-                  "offset": 708
+                  "offset": 778
                 },
                 "indent": []
               }
@@ -1736,14 +1805,14 @@
           ],
           "position": {
             "start": {
-              "line": 42,
+              "line": 44,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 42,
+              "line": 44,
               "column": 9,
-              "offset": 710
+              "offset": 780
             },
             "indent": []
           }
@@ -1751,14 +1820,14 @@
       ],
       "position": {
         "start": {
-          "line": 42,
+          "line": 44,
           "column": 1,
-          "offset": 702
+          "offset": 772
         },
         "end": {
-          "line": 42,
+          "line": 44,
           "column": 9,
-          "offset": 710
+          "offset": 780
         },
         "indent": []
       }
@@ -1771,14 +1840,14 @@
           "value": "Colon should not be escaped in URLs:",
           "position": {
             "start": {
-              "line": 44,
+              "line": 46,
               "column": 1,
-              "offset": 712
+              "offset": 782
             },
             "end": {
-              "line": 44,
+              "line": 46,
               "column": 37,
-              "offset": 748
+              "offset": 818
             },
             "indent": []
           }
@@ -1786,14 +1855,14 @@
       ],
       "position": {
         "start": {
-          "line": 44,
+          "line": 46,
           "column": 1,
-          "offset": 712
+          "offset": 782
         },
         "end": {
-          "line": 44,
+          "line": 46,
           "column": 37,
-          "offset": 748
+          "offset": 818
         },
         "indent": []
       }
@@ -1817,14 +1886,14 @@
                   "value": "http://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 46,
+                      "line": 48,
                       "column": 5,
-                      "offset": 754
+                      "offset": 824
                     },
                     "end": {
-                      "line": 46,
+                      "line": 48,
                       "column": 59,
-                      "offset": 808
+                      "offset": 878
                     },
                     "indent": []
                   }
@@ -1832,14 +1901,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 46,
+                  "line": 48,
                   "column": 5,
-                  "offset": 754
+                  "offset": 824
                 },
                 "end": {
-                  "line": 46,
+                  "line": 48,
                   "column": 59,
-                  "offset": 808
+                  "offset": 878
                 },
                 "indent": []
               }
@@ -1847,14 +1916,14 @@
           ],
           "position": {
             "start": {
-              "line": 46,
+              "line": 48,
               "column": 1,
-              "offset": 750
+              "offset": 820
             },
             "end": {
-              "line": 46,
+              "line": 48,
               "column": 59,
-              "offset": 808
+              "offset": 878
             },
             "indent": []
           }
@@ -1872,14 +1941,14 @@
                   "value": "https://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 813
+                      "offset": 883
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 868
+                      "offset": 938
                     },
                     "indent": []
                   }
@@ -1887,14 +1956,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 813
+                  "offset": 883
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 868
+                  "offset": 938
                 },
                 "indent": []
               }
@@ -1902,14 +1971,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 809
+              "offset": 879
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 868
+              "offset": 938
             },
             "indent": []
           }
@@ -1917,14 +1986,14 @@
       ],
       "position": {
         "start": {
-          "line": 46,
+          "line": 48,
           "column": 1,
-          "offset": 750
+          "offset": 820
         },
         "end": {
-          "line": 47,
+          "line": 49,
           "column": 60,
-          "offset": 868
+          "offset": 938
         },
         "indent": [
           1
@@ -1939,14 +2008,14 @@
           "value": "Double tildes should not be ~~escaped~~.\nNor here: foo~~.",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 870
+              "offset": 940
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 17,
-              "offset": 927
+              "offset": 997
             },
             "indent": [
               1
@@ -1956,14 +2025,14 @@
       ],
       "position": {
         "start": {
-          "line": 49,
+          "line": 51,
           "column": 1,
-          "offset": 870
+          "offset": 940
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 17,
-          "offset": 927
+          "offset": 997
         },
         "indent": [
           1
@@ -1978,14 +2047,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 929
+              "offset": 999
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 36,
-              "offset": 964
+              "offset": 1034
             },
             "indent": []
           }
@@ -1993,14 +2062,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 929
+          "offset": 999
         },
         "end": {
-          "line": 52,
+          "line": 54,
           "column": 36,
-          "offset": 964
+          "offset": 1034
         },
         "indent": []
       }
@@ -2013,14 +2082,14 @@
           "value": "| here   | they     |\n| ------ | -------- |\n| should | nei|ther |",
           "position": {
             "start": {
-              "line": 54,
+              "line": 56,
               "column": 1,
-              "offset": 966
+              "offset": 1036
             },
             "end": {
-              "line": 56,
+              "line": 58,
               "column": 22,
-              "offset": 1031
+              "offset": 1101
             },
             "indent": [
               1,
@@ -2031,14 +2100,14 @@
       ],
       "position": {
         "start": {
-          "line": 54,
+          "line": 56,
           "column": 1,
-          "offset": 966
+          "offset": 1036
         },
         "end": {
-          "line": 56,
+          "line": 58,
           "column": 22,
-          "offset": 1031
+          "offset": 1101
         },
         "indent": [
           1,
@@ -2054,14 +2123,14 @@
           "value": "Nor here:",
           "position": {
             "start": {
-              "line": 58,
+              "line": 60,
               "column": 1,
-              "offset": 1033
+              "offset": 1103
             },
             "end": {
-              "line": 58,
+              "line": 60,
               "column": 10,
-              "offset": 1042
+              "offset": 1112
             },
             "indent": []
           }
@@ -2069,14 +2138,14 @@
       ],
       "position": {
         "start": {
-          "line": 58,
+          "line": 60,
           "column": 1,
-          "offset": 1033
+          "offset": 1103
         },
         "end": {
-          "line": 58,
+          "line": 60,
           "column": 10,
-          "offset": 1042
+          "offset": 1112
         },
         "indent": []
       }
@@ -2089,14 +2158,14 @@
           "value": "| here   | they   |\n| ------ | ------ |\n| should | though |",
           "position": {
             "start": {
-              "line": 60,
+              "line": 62,
               "column": 1,
-              "offset": 1044
+              "offset": 1114
             },
             "end": {
-              "line": 62,
+              "line": 64,
               "column": 20,
-              "offset": 1103
+              "offset": 1173
             },
             "indent": [
               1,
@@ -2107,14 +2176,14 @@
       ],
       "position": {
         "start": {
-          "line": 60,
+          "line": 62,
           "column": 1,
-          "offset": 1044
+          "offset": 1114
         },
         "end": {
-          "line": 62,
+          "line": 64,
           "column": 20,
-          "offset": 1103
+          "offset": 1173
         },
         "indent": [
           1,
@@ -2130,14 +2199,14 @@
           "value": "Nor here:",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1105
+              "offset": 1175
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 10,
-              "offset": 1114
+              "offset": 1184
             },
             "indent": []
           }
@@ -2145,14 +2214,14 @@
       ],
       "position": {
         "start": {
-          "line": 64,
+          "line": 66,
           "column": 1,
-          "offset": 1105
+          "offset": 1175
         },
         "end": {
-          "line": 64,
+          "line": 66,
           "column": 10,
-          "offset": 1114
+          "offset": 1184
         },
         "indent": []
       }
@@ -2165,14 +2234,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 66,
+              "line": 68,
               "column": 1,
-              "offset": 1116
+              "offset": 1186
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "indent": [
               1
@@ -2184,14 +2253,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 3,
-              "offset": 1132
+              "offset": 1202
             },
             "indent": []
           }
@@ -2201,14 +2270,14 @@
           "value": "---- | ------\nshould | though",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 3,
-              "offset": 1132
+              "offset": 1202
             },
             "end": {
-              "line": 68,
+              "line": 70,
               "column": 16,
-              "offset": 1161
+              "offset": 1231
             },
             "indent": [
               1
@@ -2218,14 +2287,14 @@
       ],
       "position": {
         "start": {
-          "line": 66,
+          "line": 68,
           "column": 1,
-          "offset": 1116
+          "offset": 1186
         },
         "end": {
-          "line": 68,
+          "line": 70,
           "column": 16,
-          "offset": 1161
+          "offset": 1231
         },
         "indent": [
           1,
@@ -2244,14 +2313,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 70,
+                  "line": 72,
                   "column": 3,
-                  "offset": 1165
+                  "offset": 1235
                 },
                 "end": {
-                  "line": 70,
+                  "line": 72,
                   "column": 14,
-                  "offset": 1176
+                  "offset": 1246
                 },
                 "indent": []
               }
@@ -2259,14 +2328,14 @@
           ],
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1163
+              "offset": 1233
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 16,
-              "offset": 1178
+              "offset": 1248
             },
             "indent": []
           }
@@ -2274,14 +2343,14 @@
       ],
       "position": {
         "start": {
-          "line": 70,
+          "line": 72,
           "column": 1,
-          "offset": 1163
+          "offset": 1233
         },
         "end": {
-          "line": 70,
+          "line": 72,
           "column": 16,
-          "offset": 1178
+          "offset": 1248
         },
         "indent": []
       }
@@ -2294,14 +2363,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 72,
+              "line": 74,
               "column": 1,
-              "offset": 1180
+              "offset": 1250
             },
             "end": {
-              "line": 72,
+              "line": 74,
               "column": 38,
-              "offset": 1217
+              "offset": 1287
             },
             "indent": []
           }
@@ -2309,14 +2378,14 @@
       ],
       "position": {
         "start": {
-          "line": 72,
+          "line": 74,
           "column": 1,
-          "offset": 1180
+          "offset": 1250
         },
         "end": {
-          "line": 72,
+          "line": 74,
           "column": 38,
-          "offset": 1217
+          "offset": 1287
         },
         "indent": []
       }
@@ -2340,14 +2409,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 5,
-                      "offset": 1223
+                      "offset": 1293
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 7,
-                      "offset": 1225
+                      "offset": 1295
                     },
                     "indent": []
                   }
@@ -2357,14 +2426,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 7,
-                      "offset": 1225
+                      "offset": 1295
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 11,
-                      "offset": 1229
+                      "offset": 1299
                     },
                     "indent": []
                   }
@@ -2374,14 +2443,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 11,
-                      "offset": 1229
+                      "offset": 1299
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 13,
-                      "offset": 1231
+                      "offset": 1301
                     },
                     "indent": []
                   }
@@ -2391,14 +2460,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 13,
-                      "offset": 1231
+                      "offset": 1301
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 18,
-                      "offset": 1236
+                      "offset": 1306
                     },
                     "indent": []
                   }
@@ -2406,14 +2475,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 74,
+                  "line": 76,
                   "column": 5,
-                  "offset": 1223
+                  "offset": 1293
                 },
                 "end": {
-                  "line": 74,
+                  "line": 76,
                   "column": 18,
-                  "offset": 1236
+                  "offset": 1306
                 },
                 "indent": []
               }
@@ -2421,14 +2490,14 @@
           ],
           "position": {
             "start": {
-              "line": 74,
+              "line": 76,
               "column": 1,
-              "offset": 1219
+              "offset": 1289
             },
             "end": {
-              "line": 74,
+              "line": 76,
               "column": 18,
-              "offset": 1236
+              "offset": 1306
             },
             "indent": []
           }
@@ -2446,14 +2515,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 5,
-                      "offset": 1241
+                      "offset": 1311
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 7,
-                      "offset": 1243
+                      "offset": 1313
                     },
                     "indent": []
                   }
@@ -2463,14 +2532,14 @@
                   "value": "http:google.com>",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 7,
-                      "offset": 1243
+                      "offset": 1313
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 23,
-                      "offset": 1259
+                      "offset": 1329
                     },
                     "indent": []
                   }
@@ -2478,14 +2547,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 75,
+                  "line": 77,
                   "column": 5,
-                  "offset": 1241
+                  "offset": 1311
                 },
                 "end": {
-                  "line": 75,
+                  "line": 77,
                   "column": 23,
-                  "offset": 1259
+                  "offset": 1329
                 },
                 "indent": []
               }
@@ -2493,14 +2562,14 @@
           ],
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1237
+              "offset": 1307
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 23,
-              "offset": 1259
+              "offset": 1329
             },
             "indent": []
           }
@@ -2508,14 +2577,14 @@
       ],
       "position": {
         "start": {
-          "line": 74,
+          "line": 76,
           "column": 1,
-          "offset": 1219
+          "offset": 1289
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 23,
-          "offset": 1259
+          "offset": 1329
         },
         "indent": [
           1
@@ -2530,9 +2599,9 @@
       "offset": 0
     },
     "end": {
-      "line": 76,
+      "line": 78,
       "column": 1,
-      "offset": 1260
+      "offset": 1330
     }
   }
 }

--- a/test/tree/stringify-escape.output.nogfm.nogfm.json
+++ b/test/tree/stringify-escape.output.nogfm.nogfm.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,115 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in_the_middle_of_a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +354,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +369,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +400,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 10,
-                      "offset": 198
+                      "offset": 268
                     },
                     "indent": []
                   }
@@ -348,14 +417,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 10,
-                      "offset": 198
+                      "offset": 268
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 18,
-                      "offset": 206
+                      "offset": 276
                     },
                     "indent": []
                   }
@@ -365,14 +434,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 18,
-                      "offset": 206
+                      "offset": 276
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "indent": []
                   }
@@ -382,14 +451,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -399,14 +468,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 33,
-                      "offset": 221
+                      "offset": 291
                     },
                     "indent": []
                   }
@@ -416,14 +485,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 33,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 37,
-                      "offset": 225
+                      "offset": 295
                     },
                     "indent": []
                   }
@@ -431,14 +500,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 37,
-                  "offset": 225
+                  "offset": 295
                 },
                 "indent": []
               }
@@ -446,14 +515,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 37,
-              "offset": 225
+              "offset": 295
             },
             "indent": []
           }
@@ -471,14 +540,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 230
+                      "offset": 300
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 16,
-                      "offset": 241
+                      "offset": 311
                     },
                     "indent": []
                   }
@@ -488,14 +557,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 16,
-                      "offset": 241
+                      "offset": 311
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 27,
-                      "offset": 252
+                      "offset": 322
                     },
                     "indent": []
                   }
@@ -505,14 +574,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 27,
-                      "offset": 252
+                      "offset": 322
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 43,
-                      "offset": 268
+                      "offset": 338
                     },
                     "indent": []
                   }
@@ -520,14 +589,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 230
+                  "offset": 300
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 43,
-                  "offset": 268
+                  "offset": 338
                 },
                 "indent": []
               }
@@ -535,14 +604,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 226
+              "offset": 296
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 43,
-              "offset": 268
+              "offset": 338
             },
             "indent": []
           }
@@ -550,14 +619,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 12,
+          "line": 14,
           "column": 43,
-          "offset": 268
+          "offset": 338
         },
         "indent": [
           1
@@ -572,14 +641,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 14,
+              "line": 16,
               "column": 1,
-              "offset": 270
+              "offset": 340
             },
             "end": {
-              "line": 14,
+              "line": 16,
               "column": 63,
-              "offset": 332
+              "offset": 402
             },
             "indent": []
           }
@@ -587,14 +656,14 @@
       ],
       "position": {
         "start": {
-          "line": 14,
+          "line": 16,
           "column": 1,
-          "offset": 270
+          "offset": 340
         },
         "end": {
-          "line": 14,
+          "line": 16,
           "column": 63,
-          "offset": 332
+          "offset": 402
         },
         "indent": []
       }
@@ -612,14 +681,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 16,
+                  "line": 18,
                   "column": 2,
-                  "offset": 335
+                  "offset": 405
                 },
                 "end": {
-                  "line": 16,
+                  "line": 18,
                   "column": 5,
-                  "offset": 338
+                  "offset": 408
                 },
                 "indent": []
               }
@@ -627,14 +696,14 @@
           ],
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 1,
-              "offset": 334
+              "offset": 404
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 6,
-              "offset": 339
+              "offset": 409
             },
             "indent": []
           }
@@ -644,14 +713,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 6,
-              "offset": 339
+              "offset": 409
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 8,
-              "offset": 341
+              "offset": 411
             },
             "indent": []
           }
@@ -661,14 +730,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 16,
+              "line": 18,
               "column": 8,
-              "offset": 341
+              "offset": 411
             },
             "end": {
-              "line": 16,
+              "line": 18,
               "column": 13,
-              "offset": 346
+              "offset": 416
             },
             "indent": []
           }
@@ -676,14 +745,14 @@
       ],
       "position": {
         "start": {
-          "line": 16,
+          "line": 18,
           "column": 1,
-          "offset": 334
+          "offset": 404
         },
         "end": {
-          "line": 16,
+          "line": 18,
           "column": 13,
-          "offset": 346
+          "offset": 416
         },
         "indent": []
       }
@@ -696,14 +765,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 18,
+              "line": 20,
               "column": 1,
-              "offset": 348
+              "offset": 418
             },
             "end": {
-              "line": 18,
+              "line": 20,
               "column": 53,
-              "offset": 400
+              "offset": 470
             },
             "indent": []
           }
@@ -711,14 +780,14 @@
       ],
       "position": {
         "start": {
-          "line": 18,
+          "line": 20,
           "column": 1,
-          "offset": 348
+          "offset": 418
         },
         "end": {
-          "line": 18,
+          "line": 20,
           "column": 53,
-          "offset": 400
+          "offset": 470
         },
         "indent": []
       }
@@ -731,14 +800,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 20,
+              "line": 22,
               "column": 1,
-              "offset": 402
+              "offset": 472
             },
             "end": {
-              "line": 20,
+              "line": 22,
               "column": 3,
-              "offset": 404
+              "offset": 474
             },
             "indent": []
           }
@@ -748,14 +817,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 20,
+              "line": 22,
               "column": 3,
-              "offset": 404
+              "offset": 474
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 421
+              "offset": 491
             },
             "indent": [
               1
@@ -767,14 +836,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 421
+              "offset": 491
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 423
+              "offset": 493
             },
             "indent": []
           }
@@ -784,14 +853,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 423
+              "offset": 493
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 442
+              "offset": 512
             },
             "indent": [
               1
@@ -803,14 +872,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 442
+              "offset": 512
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 5,
-              "offset": 444
+              "offset": 514
             },
             "indent": []
           }
@@ -820,14 +889,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 5,
-              "offset": 444
+              "offset": 514
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 21,
-              "offset": 460
+              "offset": 530
             },
             "indent": []
           }
@@ -835,14 +904,14 @@
       ],
       "position": {
         "start": {
-          "line": 20,
+          "line": 22,
           "column": 1,
-          "offset": 402
+          "offset": 472
         },
         "end": {
-          "line": 22,
+          "line": 24,
           "column": 21,
-          "offset": 460
+          "offset": 530
         },
         "indent": [
           1,
@@ -858,14 +927,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 24,
+              "line": 26,
               "column": 1,
-              "offset": 462
+              "offset": 532
             },
             "end": {
-              "line": 24,
+              "line": 26,
               "column": 25,
-              "offset": 486
+              "offset": 556
             },
             "indent": []
           }
@@ -873,14 +942,14 @@
       ],
       "position": {
         "start": {
-          "line": 24,
+          "line": 26,
           "column": 1,
-          "offset": 462
+          "offset": 532
         },
         "end": {
-          "line": 24,
+          "line": 26,
           "column": 25,
-          "offset": 486
+          "offset": 556
         },
         "indent": []
       }
@@ -893,14 +962,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 1,
-              "offset": 488
+              "offset": 558
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 3,
-              "offset": 490
+              "offset": 560
             },
             "indent": []
           }
@@ -910,14 +979,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 26,
+              "line": 28,
               "column": 3,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 26,
+              "line": 28,
               "column": 21,
-              "offset": 508
+              "offset": 578
             },
             "indent": []
           }
@@ -925,14 +994,14 @@
       ],
       "position": {
         "start": {
-          "line": 26,
+          "line": 28,
           "column": 1,
-          "offset": 488
+          "offset": 558
         },
         "end": {
-          "line": 26,
+          "line": 28,
           "column": 21,
-          "offset": 508
+          "offset": 578
         },
         "indent": []
       }
@@ -945,14 +1014,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 28,
+              "line": 30,
               "column": 1,
-              "offset": 510
+              "offset": 580
             },
             "end": {
-              "line": 28,
+              "line": 30,
               "column": 16,
-              "offset": 525
+              "offset": 595
             },
             "indent": []
           }
@@ -960,14 +1029,14 @@
       ],
       "position": {
         "start": {
-          "line": 28,
+          "line": 30,
           "column": 1,
-          "offset": 510
+          "offset": 580
         },
         "end": {
-          "line": 28,
+          "line": 30,
           "column": 16,
-          "offset": 525
+          "offset": 595
         },
         "indent": []
       }
@@ -980,14 +1049,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 1,
-              "offset": 527
+              "offset": 597
             },
             "end": {
-              "line": 30,
+              "line": 32,
               "column": 3,
-              "offset": 529
+              "offset": 599
             },
             "indent": []
           }
@@ -997,14 +1066,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 30,
+              "line": 32,
               "column": 3,
-              "offset": 529
+              "offset": 599
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 546
+              "offset": 616
             },
             "indent": [
               1
@@ -1016,14 +1085,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 546
+              "offset": 616
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 5,
-              "offset": 548
+              "offset": 618
             },
             "indent": []
           }
@@ -1033,14 +1102,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 5,
-              "offset": 548
+              "offset": 618
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 23,
-              "offset": 566
+              "offset": 636
             },
             "indent": []
           }
@@ -1048,14 +1117,14 @@
       ],
       "position": {
         "start": {
-          "line": 30,
+          "line": 32,
           "column": 1,
-          "offset": 527
+          "offset": 597
         },
         "end": {
-          "line": 31,
+          "line": 33,
           "column": 23,
-          "offset": 566
+          "offset": 636
         },
         "indent": [
           1
@@ -1070,14 +1139,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 33,
+              "line": 35,
               "column": 1,
-              "offset": 568
+              "offset": 638
             },
             "end": {
-              "line": 33,
+              "line": 35,
               "column": 62,
-              "offset": 629
+              "offset": 699
             },
             "indent": []
           }
@@ -1085,14 +1154,14 @@
       ],
       "position": {
         "start": {
-          "line": 33,
+          "line": 35,
           "column": 1,
-          "offset": 568
+          "offset": 638
         },
         "end": {
-          "line": 33,
+          "line": 35,
           "column": 62,
-          "offset": 629
+          "offset": 699
         },
         "indent": []
       }
@@ -1121,14 +1190,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 35,
+                          "line": 37,
                           "column": 6,
-                          "offset": 636
+                          "offset": 706
                         },
                         "end": {
-                          "line": 35,
+                          "line": 37,
                           "column": 15,
-                          "offset": 645
+                          "offset": 715
                         },
                         "indent": []
                       }
@@ -1136,14 +1205,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 35,
+                      "line": 37,
                       "column": 5,
-                      "offset": 635
+                      "offset": 705
                     },
                     "end": {
-                      "line": 35,
+                      "line": 37,
                       "column": 16,
-                      "offset": 646
+                      "offset": 716
                     },
                     "indent": []
                   }
@@ -1151,14 +1220,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 35,
+                  "line": 37,
                   "column": 5,
-                  "offset": 635
+                  "offset": 705
                 },
                 "end": {
-                  "line": 35,
+                  "line": 37,
                   "column": 16,
-                  "offset": 646
+                  "offset": 716
                 },
                 "indent": []
               }
@@ -1166,14 +1235,14 @@
           ],
           "position": {
             "start": {
-              "line": 35,
+              "line": 37,
               "column": 1,
-              "offset": 631
+              "offset": 701
             },
             "end": {
-              "line": 35,
+              "line": 37,
               "column": 16,
-              "offset": 646
+              "offset": 716
             },
             "indent": []
           }
@@ -1196,14 +1265,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 652
+                          "offset": 722
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 9,
-                          "offset": 655
+                          "offset": 725
                         },
                         "indent": []
                       }
@@ -1213,14 +1282,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 9,
-                          "offset": 655
+                          "offset": 725
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 11,
-                          "offset": 657
+                          "offset": 727
                         },
                         "indent": []
                       }
@@ -1230,14 +1299,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 11,
-                          "offset": 657
+                          "offset": 727
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 16,
-                          "offset": 662
+                          "offset": 732
                         },
                         "indent": []
                       }
@@ -1245,14 +1314,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 651
+                      "offset": 721
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 17,
-                      "offset": 663
+                      "offset": 733
                     },
                     "indent": []
                   }
@@ -1260,14 +1329,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 651
+                  "offset": 721
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 17,
-                  "offset": 663
+                  "offset": 733
                 },
                 "indent": []
               }
@@ -1275,14 +1344,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 647
+              "offset": 717
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 17,
-              "offset": 663
+              "offset": 733
             },
             "indent": []
           }
@@ -1305,14 +1374,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 669
+                          "offset": 739
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 672
+                          "offset": 742
                         },
                         "indent": []
                       }
@@ -1320,14 +1389,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 668
+                      "offset": 738
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 10,
-                      "offset": 673
+                      "offset": 743
                     },
                     "indent": []
                   }
@@ -1335,14 +1404,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 668
+                  "offset": 738
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 10,
-                  "offset": 673
+                  "offset": 743
                 },
                 "indent": []
               }
@@ -1350,14 +1419,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 664
+              "offset": 734
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 10,
-              "offset": 673
+              "offset": 743
             },
             "indent": []
           }
@@ -1380,14 +1449,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 679
+                          "offset": 749
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 7,
-                          "offset": 680
+                          "offset": 750
                         },
                         "indent": []
                       }
@@ -1397,14 +1466,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 7,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 682
+                          "offset": 752
                         },
                         "indent": []
                       }
@@ -1414,14 +1483,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 682
+                          "offset": 752
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 10,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1429,14 +1498,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 678
+                      "offset": 748
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 11,
-                      "offset": 684
+                      "offset": 754
                     },
                     "indent": []
                   }
@@ -1444,14 +1513,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 678
+                  "offset": 748
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 11,
-                  "offset": 684
+                  "offset": 754
                 },
                 "indent": []
               }
@@ -1459,14 +1528,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 674
+              "offset": 744
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 11,
-              "offset": 684
+              "offset": 754
             },
             "indent": []
           }
@@ -1489,14 +1558,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 690
+                          "offset": 760
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 691
+                          "offset": 761
                         },
                         "indent": []
                       }
@@ -1506,14 +1575,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 691
+                          "offset": 761
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 693
+                          "offset": 763
                         },
                         "indent": []
                       }
@@ -1523,14 +1592,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 693
+                          "offset": 763
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 11,
-                          "offset": 695
+                          "offset": 765
                         },
                         "indent": []
                       }
@@ -1538,14 +1607,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 689
+                      "offset": 759
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 12,
-                      "offset": 696
+                      "offset": 766
                     },
                     "indent": []
                   }
@@ -1553,14 +1622,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 689
+                  "offset": 759
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 12,
-                  "offset": 696
+                  "offset": 766
                 },
                 "indent": []
               }
@@ -1568,14 +1637,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 685
+              "offset": 755
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 12,
-              "offset": 696
+              "offset": 766
             },
             "indent": []
           }
@@ -1598,14 +1667,14 @@
                       "value": "a_a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 702
+                          "offset": 772
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 705
+                          "offset": 775
                         },
                         "indent": []
                       }
@@ -1615,14 +1684,14 @@
                       "value": "_",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 705
+                          "offset": 775
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 707
+                          "offset": 777
                         },
                         "indent": []
                       }
@@ -1632,14 +1701,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 12,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1647,14 +1716,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 701
+                      "offset": 771
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 13,
-                      "offset": 709
+                      "offset": 779
                     },
                     "indent": []
                   }
@@ -1662,14 +1731,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 701
+                  "offset": 771
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 13,
-                  "offset": 709
+                  "offset": 779
                 },
                 "indent": []
               }
@@ -1677,14 +1746,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 697
+              "offset": 767
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 13,
-              "offset": 709
+              "offset": 779
             },
             "indent": []
           }
@@ -1692,14 +1761,14 @@
       ],
       "position": {
         "start": {
-          "line": 35,
+          "line": 37,
           "column": 1,
-          "offset": 631
+          "offset": 701
         },
         "end": {
-          "line": 40,
+          "line": 42,
           "column": 13,
-          "offset": 709
+          "offset": 779
         },
         "indent": [
           1,
@@ -1721,14 +1790,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 42,
+                  "line": 44,
                   "column": 3,
-                  "offset": 713
+                  "offset": 783
                 },
                 "end": {
-                  "line": 42,
+                  "line": 44,
                   "column": 7,
-                  "offset": 717
+                  "offset": 787
                 },
                 "indent": []
               }
@@ -1736,14 +1805,14 @@
           ],
           "position": {
             "start": {
-              "line": 42,
+              "line": 44,
               "column": 1,
-              "offset": 711
+              "offset": 781
             },
             "end": {
-              "line": 42,
+              "line": 44,
               "column": 9,
-              "offset": 719
+              "offset": 789
             },
             "indent": []
           }
@@ -1751,14 +1820,14 @@
       ],
       "position": {
         "start": {
-          "line": 42,
+          "line": 44,
           "column": 1,
-          "offset": 711
+          "offset": 781
         },
         "end": {
-          "line": 42,
+          "line": 44,
           "column": 9,
-          "offset": 719
+          "offset": 789
         },
         "indent": []
       }
@@ -1771,14 +1840,14 @@
           "value": "Colon should not be escaped in URLs:",
           "position": {
             "start": {
-              "line": 44,
+              "line": 46,
               "column": 1,
-              "offset": 721
+              "offset": 791
             },
             "end": {
-              "line": 44,
+              "line": 46,
               "column": 37,
-              "offset": 757
+              "offset": 827
             },
             "indent": []
           }
@@ -1786,14 +1855,14 @@
       ],
       "position": {
         "start": {
-          "line": 44,
+          "line": 46,
           "column": 1,
-          "offset": 721
+          "offset": 791
         },
         "end": {
-          "line": 44,
+          "line": 46,
           "column": 37,
-          "offset": 757
+          "offset": 827
         },
         "indent": []
       }
@@ -1817,14 +1886,14 @@
                   "value": "http://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 46,
+                      "line": 48,
                       "column": 5,
-                      "offset": 763
+                      "offset": 833
                     },
                     "end": {
-                      "line": 46,
+                      "line": 48,
                       "column": 59,
-                      "offset": 817
+                      "offset": 887
                     },
                     "indent": []
                   }
@@ -1832,14 +1901,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 46,
+                  "line": 48,
                   "column": 5,
-                  "offset": 763
+                  "offset": 833
                 },
                 "end": {
-                  "line": 46,
+                  "line": 48,
                   "column": 59,
-                  "offset": 817
+                  "offset": 887
                 },
                 "indent": []
               }
@@ -1847,14 +1916,14 @@
           ],
           "position": {
             "start": {
-              "line": 46,
+              "line": 48,
               "column": 1,
-              "offset": 759
+              "offset": 829
             },
             "end": {
-              "line": 46,
+              "line": 48,
               "column": 59,
-              "offset": 817
+              "offset": 887
             },
             "indent": []
           }
@@ -1872,14 +1941,14 @@
                   "value": "https://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 822
+                      "offset": 892
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 877
+                      "offset": 947
                     },
                     "indent": []
                   }
@@ -1887,14 +1956,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 822
+                  "offset": 892
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 877
+                  "offset": 947
                 },
                 "indent": []
               }
@@ -1902,14 +1971,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 818
+              "offset": 888
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 877
+              "offset": 947
             },
             "indent": []
           }
@@ -1917,14 +1986,14 @@
       ],
       "position": {
         "start": {
-          "line": 46,
+          "line": 48,
           "column": 1,
-          "offset": 759
+          "offset": 829
         },
         "end": {
-          "line": 47,
+          "line": 49,
           "column": 60,
-          "offset": 877
+          "offset": 947
         },
         "indent": [
           1
@@ -1939,14 +2008,14 @@
           "value": "Double tildes should not be ~~escaped~~.\nNor here: foo~~.",
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 879
+              "offset": 949
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 17,
-              "offset": 936
+              "offset": 1006
             },
             "indent": [
               1
@@ -1956,14 +2025,14 @@
       ],
       "position": {
         "start": {
-          "line": 49,
+          "line": 51,
           "column": 1,
-          "offset": 879
+          "offset": 949
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 17,
-          "offset": 936
+          "offset": 1006
         },
         "indent": [
           1
@@ -1978,14 +2047,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 938
+              "offset": 1008
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 36,
-              "offset": 973
+              "offset": 1043
             },
             "indent": []
           }
@@ -1993,14 +2062,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 938
+          "offset": 1008
         },
         "end": {
-          "line": 52,
+          "line": 54,
           "column": 36,
-          "offset": 973
+          "offset": 1043
         },
         "indent": []
       }
@@ -2013,14 +2082,14 @@
           "value": "| here   | they     |\n| ------ | -------- |\n| should | nei|ther |",
           "position": {
             "start": {
-              "line": 54,
+              "line": 56,
               "column": 1,
-              "offset": 975
+              "offset": 1045
             },
             "end": {
-              "line": 56,
+              "line": 58,
               "column": 22,
-              "offset": 1040
+              "offset": 1110
             },
             "indent": [
               1,
@@ -2031,14 +2100,14 @@
       ],
       "position": {
         "start": {
-          "line": 54,
+          "line": 56,
           "column": 1,
-          "offset": 975
+          "offset": 1045
         },
         "end": {
-          "line": 56,
+          "line": 58,
           "column": 22,
-          "offset": 1040
+          "offset": 1110
         },
         "indent": [
           1,
@@ -2054,14 +2123,14 @@
           "value": "Nor here:",
           "position": {
             "start": {
-              "line": 58,
+              "line": 60,
               "column": 1,
-              "offset": 1042
+              "offset": 1112
             },
             "end": {
-              "line": 58,
+              "line": 60,
               "column": 10,
-              "offset": 1051
+              "offset": 1121
             },
             "indent": []
           }
@@ -2069,14 +2138,14 @@
       ],
       "position": {
         "start": {
-          "line": 58,
+          "line": 60,
           "column": 1,
-          "offset": 1042
+          "offset": 1112
         },
         "end": {
-          "line": 58,
+          "line": 60,
           "column": 10,
-          "offset": 1051
+          "offset": 1121
         },
         "indent": []
       }
@@ -2089,14 +2158,14 @@
           "value": "| here   | they   |\n| ------ | ------ |\n| should | though |",
           "position": {
             "start": {
-              "line": 60,
+              "line": 62,
               "column": 1,
-              "offset": 1053
+              "offset": 1123
             },
             "end": {
-              "line": 62,
+              "line": 64,
               "column": 20,
-              "offset": 1112
+              "offset": 1182
             },
             "indent": [
               1,
@@ -2107,14 +2176,14 @@
       ],
       "position": {
         "start": {
-          "line": 60,
+          "line": 62,
           "column": 1,
-          "offset": 1053
+          "offset": 1123
         },
         "end": {
-          "line": 62,
+          "line": 64,
           "column": 20,
-          "offset": 1112
+          "offset": 1182
         },
         "indent": [
           1,
@@ -2130,14 +2199,14 @@
           "value": "Nor here:",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1114
+              "offset": 1184
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 10,
-              "offset": 1123
+              "offset": 1193
             },
             "indent": []
           }
@@ -2145,14 +2214,14 @@
       ],
       "position": {
         "start": {
-          "line": 64,
+          "line": 66,
           "column": 1,
-          "offset": 1114
+          "offset": 1184
         },
         "end": {
-          "line": 64,
+          "line": 66,
           "column": 10,
-          "offset": 1123
+          "offset": 1193
         },
         "indent": []
       }
@@ -2165,14 +2234,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 66,
+              "line": 68,
               "column": 1,
-              "offset": 1125
+              "offset": 1195
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1139
+              "offset": 1209
             },
             "indent": [
               1
@@ -2184,14 +2253,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1139
+              "offset": 1209
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 3,
-              "offset": 1141
+              "offset": 1211
             },
             "indent": []
           }
@@ -2201,14 +2270,14 @@
           "value": "---- | ------\nshould | though",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 3,
-              "offset": 1141
+              "offset": 1211
             },
             "end": {
-              "line": 68,
+              "line": 70,
               "column": 16,
-              "offset": 1170
+              "offset": 1240
             },
             "indent": [
               1
@@ -2218,14 +2287,14 @@
       ],
       "position": {
         "start": {
-          "line": 66,
+          "line": 68,
           "column": 1,
-          "offset": 1125
+          "offset": 1195
         },
         "end": {
-          "line": 68,
+          "line": 70,
           "column": 16,
-          "offset": 1170
+          "offset": 1240
         },
         "indent": [
           1,
@@ -2244,14 +2313,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 70,
+                  "line": 72,
                   "column": 3,
-                  "offset": 1174
+                  "offset": 1244
                 },
                 "end": {
-                  "line": 70,
+                  "line": 72,
                   "column": 14,
-                  "offset": 1185
+                  "offset": 1255
                 },
                 "indent": []
               }
@@ -2259,14 +2328,14 @@
           ],
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1172
+              "offset": 1242
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 16,
-              "offset": 1187
+              "offset": 1257
             },
             "indent": []
           }
@@ -2274,14 +2343,14 @@
       ],
       "position": {
         "start": {
-          "line": 70,
+          "line": 72,
           "column": 1,
-          "offset": 1172
+          "offset": 1242
         },
         "end": {
-          "line": 70,
+          "line": 72,
           "column": 16,
-          "offset": 1187
+          "offset": 1257
         },
         "indent": []
       }
@@ -2294,14 +2363,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 72,
+              "line": 74,
               "column": 1,
-              "offset": 1189
+              "offset": 1259
             },
             "end": {
-              "line": 72,
+              "line": 74,
               "column": 38,
-              "offset": 1226
+              "offset": 1296
             },
             "indent": []
           }
@@ -2309,14 +2378,14 @@
       ],
       "position": {
         "start": {
-          "line": 72,
+          "line": 74,
           "column": 1,
-          "offset": 1189
+          "offset": 1259
         },
         "end": {
-          "line": 72,
+          "line": 74,
           "column": 38,
-          "offset": 1226
+          "offset": 1296
         },
         "indent": []
       }
@@ -2340,14 +2409,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 5,
-                      "offset": 1232
+                      "offset": 1302
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 9,
-                      "offset": 1236
+                      "offset": 1306
                     },
                     "indent": []
                   }
@@ -2357,14 +2426,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 9,
-                      "offset": 1236
+                      "offset": 1306
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 13,
-                      "offset": 1240
+                      "offset": 1310
                     },
                     "indent": []
                   }
@@ -2374,14 +2443,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 13,
-                      "offset": 1240
+                      "offset": 1310
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 17,
-                      "offset": 1244
+                      "offset": 1314
                     },
                     "indent": []
                   }
@@ -2391,14 +2460,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 74,
+                      "line": 76,
                       "column": 17,
-                      "offset": 1244
+                      "offset": 1314
                     },
                     "end": {
-                      "line": 74,
+                      "line": 76,
                       "column": 22,
-                      "offset": 1249
+                      "offset": 1319
                     },
                     "indent": []
                   }
@@ -2406,14 +2475,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 74,
+                  "line": 76,
                   "column": 5,
-                  "offset": 1232
+                  "offset": 1302
                 },
                 "end": {
-                  "line": 74,
+                  "line": 76,
                   "column": 22,
-                  "offset": 1249
+                  "offset": 1319
                 },
                 "indent": []
               }
@@ -2421,14 +2490,14 @@
           ],
           "position": {
             "start": {
-              "line": 74,
+              "line": 76,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "end": {
-              "line": 74,
+              "line": 76,
               "column": 22,
-              "offset": 1249
+              "offset": 1319
             },
             "indent": []
           }
@@ -2446,14 +2515,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 5,
-                      "offset": 1254
+                      "offset": 1324
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 9,
-                      "offset": 1258
+                      "offset": 1328
                     },
                     "indent": []
                   }
@@ -2463,14 +2532,14 @@
                   "value": "http:google.com>",
                   "position": {
                     "start": {
-                      "line": 75,
+                      "line": 77,
                       "column": 9,
-                      "offset": 1258
+                      "offset": 1328
                     },
                     "end": {
-                      "line": 75,
+                      "line": 77,
                       "column": 25,
-                      "offset": 1274
+                      "offset": 1344
                     },
                     "indent": []
                   }
@@ -2478,14 +2547,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 75,
+                  "line": 77,
                   "column": 5,
-                  "offset": 1254
+                  "offset": 1324
                 },
                 "end": {
-                  "line": 75,
+                  "line": 77,
                   "column": 25,
-                  "offset": 1274
+                  "offset": 1344
                 },
                 "indent": []
               }
@@ -2493,14 +2562,14 @@
           ],
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1250
+              "offset": 1320
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 25,
-              "offset": 1274
+              "offset": 1344
             },
             "indent": []
           }
@@ -2508,14 +2577,14 @@
       ],
       "position": {
         "start": {
-          "line": 74,
+          "line": 76,
           "column": 1,
-          "offset": 1228
+          "offset": 1298
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 25,
-          "offset": 1274
+          "offset": 1344
         },
         "indent": [
           1
@@ -2530,9 +2599,9 @@
       "offset": 0
     },
     "end": {
-      "line": 76,
+      "line": 78,
       "column": 1,
-      "offset": 1275
+      "offset": 1345
     }
   }
 }

--- a/test/tree/stringify-escape.output.noposition.pedantic.noposition.pedantic.json
+++ b/test/tree/stringify-escape.output.noposition.pedantic.noposition.pedantic.json
@@ -1,0 +1,877 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Characters that should be escaped in general:"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "\\"
+        },
+        {
+          "type": "text",
+          "value": " "
+        },
+        {
+          "type": "text",
+          "value": "`"
+        },
+        {
+          "type": "text",
+          "value": " "
+        },
+        {
+          "type": "text",
+          "value": "*"
+        },
+        {
+          "type": "text",
+          "value": " "
+        },
+        {
+          "type": "text",
+          "value": "["
+        },
+        {
+          "type": "text",
+          "value": " "
+        },
+        {
+          "type": "text",
+          "value": "_"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Characters that shouldn't:"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "{}]()#+-.!>\"$%',/:;=?@^~"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are always "
+        },
+        {
+          "type": "text",
+          "value": "_"
+        },
+        {
+          "type": "text",
+          "value": "escaped"
+        },
+        {
+          "type": "text",
+          "value": "_"
+        },
+        {
+          "type": "text",
+          "value": ", even when they appear in"
+        },
+        {
+          "type": "text",
+          "value": "_"
+        },
+        {
+          "type": "text",
+          "value": "the"
+        },
+        {
+          "type": "text",
+          "value": "_"
+        },
+        {
+          "type": "text",
+          "value": "middle"
+        },
+        {
+          "type": "text",
+          "value": "_"
+        },
+        {
+          "type": "text",
+          "value": "of"
+        },
+        {
+          "type": "text",
+          "value": "_"
+        },
+        {
+          "type": "text",
+          "value": "a"
+        },
+        {
+          "type": "text",
+          "value": "_"
+        },
+        {
+          "type": "text",
+          "value": "word."
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Ampersands are escaped only when they would otherwise start an entity:"
+        }
+      ]
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "&"
+                },
+                {
+                  "type": "text",
+                  "value": "copycat "
+                },
+                {
+                  "type": "text",
+                  "value": "&"
+                },
+                {
+                  "type": "text",
+                  "value": "amp; "
+                },
+                {
+                  "type": "text",
+                  "value": "&"
+                },
+                {
+                  "type": "text",
+                  "value": "#x26"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "But: ©cat; "
+                },
+                {
+                  "type": "inlineCode",
+                  "value": "&between;"
+                },
+                {
+                  "type": "text",
+                  "value": " &foo; & AT&T &c"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Open parenthesis should be escaped after a shortcut reference:"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "ref",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "ref"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "value": "("
+        },
+        {
+          "type": "text",
+          "value": "text)"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Hyphen should be escaped at the beginning of a line:"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "-"
+        },
+        {
+          "type": "text",
+          "value": " not a list item\n"
+        },
+        {
+          "type": "text",
+          "value": "-"
+        },
+        {
+          "type": "text",
+          "value": " not a list item\n  "
+        },
+        {
+          "type": "text",
+          "value": "+"
+        },
+        {
+          "type": "text",
+          "value": " not a list item"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Same for angle brackets:"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": ">"
+        },
+        {
+          "type": "text",
+          "value": " not a block quote"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "And hash signs:"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "#"
+        },
+        {
+          "type": "text",
+          "value": " not a heading\n  "
+        },
+        {
+          "type": "text",
+          "value": "#"
+        },
+        {
+          "type": "text",
+          "value": "# not a subheading"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Text under a shortcut reference should be preserved verbatim:"
+        }
+      ]
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "two*three",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "two*three"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "two\\*three",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "two"
+                    },
+                    {
+                      "type": "text",
+                      "value": "*"
+                    },
+                    {
+                      "type": "text",
+                      "value": "three"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a\\a"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a"
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\"
+                    },
+                    {
+                      "type": "text",
+                      "value": "a"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a\\\\\\a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a"
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\"
+                    },
+                    {
+                      "type": "text",
+                      "value": "\\a"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "linkReference",
+                  "identifier": "a_a\\_a",
+                  "referenceType": "shortcut",
+                  "children": [
+                    {
+                      "type": "text",
+                      "value": "a"
+                    },
+                    {
+                      "type": "emphasis",
+                      "children": [
+                        {
+                          "type": "text",
+                          "value": "a\\"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "value": "a"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "GFM:"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Colon should be escaped in URLs:"
+        }
+      ]
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "http"
+                },
+                {
+                  "type": "text",
+                  "value": ":"
+                },
+                {
+                  "type": "text",
+                  "value": "//user:password@host:port/path?key=value#fragment"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "https"
+                },
+                {
+                  "type": "text",
+                  "value": ":"
+                },
+                {
+                  "type": "text",
+                  "value": "//user:password@host:port/path?key=value#fragment"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Double tildes should be "
+        },
+        {
+          "type": "text",
+          "value": "~"
+        },
+        {
+          "type": "text",
+          "value": "~escaped"
+        },
+        {
+          "type": "text",
+          "value": "~"
+        },
+        {
+          "type": "text",
+          "value": "~.\nAnd here: foo"
+        },
+        {
+          "type": "text",
+          "value": "~"
+        },
+        {
+          "type": "text",
+          "value": "~."
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Pipes should not be escaped here: |"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "align": [
+        null,
+        null
+      ],
+      "children": [
+        {
+          "type": "tableRow",
+          "children": [
+            {
+              "type": "tableCell",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "here"
+                }
+              ]
+            },
+            {
+              "type": "tableCell",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "they"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "tableRow",
+          "children": [
+            {
+              "type": "tableCell",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "should"
+                }
+              ]
+            },
+            {
+              "type": "tableCell",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "tho"
+                },
+                {
+                  "type": "text",
+                  "value": "|"
+                },
+                {
+                  "type": "text",
+                  "value": "ugh"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "And here:"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "| here   | they   |\n"
+        },
+        {
+          "type": "text",
+          "value": "|"
+        },
+        {
+          "type": "text",
+          "value": " ---- "
+        },
+        {
+          "type": "text",
+          "value": "|"
+        },
+        {
+          "type": "text",
+          "value": " ----- "
+        },
+        {
+          "type": "text",
+          "value": "|"
+        },
+        {
+          "type": "text",
+          "value": "\n| should | though |"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "And here:"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "here   | they\n"
+        },
+        {
+          "type": "text",
+          "value": "-"
+        },
+        {
+          "type": "text",
+          "value": "--- "
+        },
+        {
+          "type": "text",
+          "value": "|"
+        },
+        {
+          "type": "text",
+          "value": " ------\nshould | though"
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "strong",
+          "children": [
+            {
+              "type": "text",
+              "value": "Commonmark:"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Open angle bracket should be escaped:"
+        }
+      ]
+    },
+    {
+      "type": "list",
+      "ordered": false,
+      "start": null,
+      "loose": false,
+      "children": [
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<"
+                },
+                {
+                  "type": "text",
+                  "value": "div>"
+                },
+                {
+                  "type": "text",
+                  "value": "<"
+                },
+                {
+                  "type": "text",
+                  "value": "/div>"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "listItem",
+          "loose": false,
+          "checked": null,
+          "children": [
+            {
+              "type": "paragraph",
+              "children": [
+                {
+                  "type": "text",
+                  "value": "<"
+                },
+                {
+                  "type": "text",
+                  "value": "http"
+                },
+                {
+                  "type": "text",
+                  "value": ":"
+                },
+                {
+                  "type": "text",
+                  "value": "google.com>"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/tree/stringify-escape.output.pedantic.pedantic.json
+++ b/test/tree/stringify-escape.output.pedantic.pedantic.json
@@ -157,6 +157,40 @@
             },
             "indent": []
           }
+        },
+        {
+          "type": "text",
+          "value": " ",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 12,
+              "offset": 58
+            },
+            "end": {
+              "line": 3,
+              "column": 13,
+              "offset": 59
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 13,
+              "offset": 59
+            },
+            "end": {
+              "line": 3,
+              "column": 15,
+              "offset": 61
+            },
+            "indent": []
+          }
         }
       ],
       "position": {
@@ -167,8 +201,8 @@
         },
         "end": {
           "line": 3,
-          "column": 12,
-          "offset": 58
+          "column": 15,
+          "offset": 61
         },
         "indent": []
       }
@@ -183,12 +217,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 60
+              "offset": 63
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 86
+              "offset": 89
             },
             "indent": []
           }
@@ -198,12 +232,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 60
+          "offset": 63
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 86
+          "offset": 89
         },
         "indent": []
       }
@@ -218,12 +252,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 88
+              "offset": 91
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 112
+              "offset": 115
             },
             "indent": []
           }
@@ -233,12 +267,12 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 88
+          "offset": 91
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 112
+          "offset": 115
         },
         "indent": []
       }
@@ -248,17 +282,17 @@
       "children": [
         {
           "type": "text",
-          "value": "Underscores are ",
+          "value": "Underscores are always ",
           "position": {
             "start": {
               "line": 9,
               "column": 1,
-              "offset": 114
+              "offset": 117
             },
             "end": {
               "line": 9,
-              "column": 17,
-              "offset": 130
+              "column": 24,
+              "offset": 140
             },
             "indent": []
           }
@@ -269,13 +303,13 @@
           "position": {
             "start": {
               "line": 9,
-              "column": 17,
-              "offset": 130
+              "column": 24,
+              "offset": 140
             },
             "end": {
               "line": 9,
-              "column": 19,
-              "offset": 132
+              "column": 26,
+              "offset": 142
             },
             "indent": []
           }
@@ -286,13 +320,13 @@
           "position": {
             "start": {
               "line": 9,
-              "column": 19,
-              "offset": 132
+              "column": 26,
+              "offset": 142
             },
             "end": {
               "line": 9,
-              "column": 26,
-              "offset": 139
+              "column": 33,
+              "offset": 149
             },
             "indent": []
           }
@@ -303,65 +337,81 @@
           "position": {
             "start": {
               "line": 9,
-              "column": 26,
-              "offset": 139
+              "column": 33,
+              "offset": 149
             },
             "end": {
               "line": 9,
-              "column": 28,
-              "offset": 141
+              "column": 35,
+              "offset": 151
             },
             "indent": []
           }
         },
         {
           "type": "text",
-          "value": " unless they appear in",
+          "value": ", even when they appear in",
           "position": {
             "start": {
               "line": 9,
-              "column": 28,
-              "offset": 141
+              "column": 35,
+              "offset": 151
             },
             "end": {
               "line": 9,
-              "column": 50,
-              "offset": 163
+              "column": 61,
+              "offset": 177
             },
             "indent": []
           }
         },
         {
-          "type": "emphasis",
-          "children": [
-            {
-              "type": "text",
-              "value": "the",
-              "position": {
-                "start": {
-                  "line": 9,
-                  "column": 51,
-                  "offset": 164
-                },
-                "end": {
-                  "line": 9,
-                  "column": 54,
-                  "offset": 167
-                },
-                "indent": []
-              }
-            }
-          ],
+          "type": "text",
+          "value": "_",
           "position": {
             "start": {
               "line": 9,
-              "column": 50,
-              "offset": 163
+              "column": 61,
+              "offset": 177
             },
             "end": {
               "line": 9,
-              "column": 55,
-              "offset": 168
+              "column": 63,
+              "offset": 179
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "the",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 63,
+              "offset": 179
+            },
+            "end": {
+              "line": 9,
+              "column": 66,
+              "offset": 182
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 66,
+              "offset": 182
+            },
+            "end": {
+              "line": 9,
+              "column": 68,
+              "offset": 184
             },
             "indent": []
           }
@@ -372,65 +422,115 @@
           "position": {
             "start": {
               "line": 9,
-              "column": 55,
-              "offset": 168
+              "column": 68,
+              "offset": 184
             },
             "end": {
               "line": 9,
-              "column": 61,
-              "offset": 174
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "emphasis",
-          "children": [
-            {
-              "type": "text",
-              "value": "of",
-              "position": {
-                "start": {
-                  "line": 9,
-                  "column": 62,
-                  "offset": 175
-                },
-                "end": {
-                  "line": 9,
-                  "column": 64,
-                  "offset": 177
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 9,
-              "column": 61,
-              "offset": 174
-            },
-            "end": {
-              "line": 9,
-              "column": 65,
-              "offset": 178
+              "column": 74,
+              "offset": 190
             },
             "indent": []
           }
         },
         {
           "type": "text",
-          "value": "a_word.",
+          "value": "_",
           "position": {
             "start": {
               "line": 9,
-              "column": 65,
-              "offset": 178
+              "column": 74,
+              "offset": 190
             },
             "end": {
               "line": 9,
-              "column": 72,
-              "offset": 185
+              "column": 76,
+              "offset": 192
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "of",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 76,
+              "offset": 192
+            },
+            "end": {
+              "line": 9,
+              "column": 78,
+              "offset": 194
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 78,
+              "offset": 194
+            },
+            "end": {
+              "line": 9,
+              "column": 80,
+              "offset": 196
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "a",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 80,
+              "offset": 196
+            },
+            "end": {
+              "line": 9,
+              "column": 81,
+              "offset": 197
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 81,
+              "offset": 197
+            },
+            "end": {
+              "line": 9,
+              "column": 83,
+              "offset": 199
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 83,
+              "offset": 199
+            },
+            "end": {
+              "line": 9,
+              "column": 88,
+              "offset": 204
             },
             "indent": []
           }
@@ -440,12 +540,12 @@
         "start": {
           "line": 9,
           "column": 1,
-          "offset": 114
+          "offset": 117
         },
         "end": {
           "line": 9,
-          "column": 72,
-          "offset": 185
+          "column": 88,
+          "offset": 204
         },
         "indent": []
       }
@@ -460,12 +560,12 @@
             "start": {
               "line": 11,
               "column": 1,
-              "offset": 187
+              "offset": 206
             },
             "end": {
               "line": 11,
               "column": 71,
-              "offset": 257
+              "offset": 276
             },
             "indent": []
           }
@@ -475,12 +575,12 @@
         "start": {
           "line": 11,
           "column": 1,
-          "offset": 187
+          "offset": 206
         },
         "end": {
           "line": 11,
           "column": 71,
-          "offset": 257
+          "offset": 276
         },
         "indent": []
       }
@@ -506,12 +606,12 @@
                     "start": {
                       "line": 13,
                       "column": 5,
-                      "offset": 263
+                      "offset": 282
                     },
                     "end": {
                       "line": 13,
-                      "column": 7,
-                      "offset": 265
+                      "column": 10,
+                      "offset": 287
                     },
                     "indent": []
                   }
@@ -522,13 +622,13 @@
                   "position": {
                     "start": {
                       "line": 13,
-                      "column": 7,
-                      "offset": 265
+                      "column": 10,
+                      "offset": 287
                     },
                     "end": {
                       "line": 13,
-                      "column": 15,
-                      "offset": 273
+                      "column": 18,
+                      "offset": 295
                     },
                     "indent": []
                   }
@@ -539,13 +639,13 @@
                   "position": {
                     "start": {
                       "line": 13,
-                      "column": 15,
-                      "offset": 273
+                      "column": 18,
+                      "offset": 295
                     },
                     "end": {
                       "line": 13,
-                      "column": 17,
-                      "offset": 275
+                      "column": 23,
+                      "offset": 300
                     },
                     "indent": []
                   }
@@ -556,13 +656,13 @@
                   "position": {
                     "start": {
                       "line": 13,
-                      "column": 17,
-                      "offset": 275
+                      "column": 23,
+                      "offset": 300
                     },
                     "end": {
                       "line": 13,
-                      "column": 22,
-                      "offset": 280
+                      "column": 28,
+                      "offset": 305
                     },
                     "indent": []
                   }
@@ -573,13 +673,13 @@
                   "position": {
                     "start": {
                       "line": 13,
-                      "column": 22,
-                      "offset": 280
+                      "column": 28,
+                      "offset": 305
                     },
                     "end": {
                       "line": 13,
-                      "column": 24,
-                      "offset": 282
+                      "column": 33,
+                      "offset": 310
                     },
                     "indent": []
                   }
@@ -590,153 +690,13 @@
                   "position": {
                     "start": {
                       "line": 13,
-                      "column": 24,
-                      "offset": 282
+                      "column": 33,
+                      "offset": 310
                     },
                     "end": {
                       "line": 13,
-                      "column": 28,
-                      "offset": 286
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 13,
-                  "column": 5,
-                  "offset": 263
-                },
-                "end": {
-                  "line": 13,
-                  "column": 28,
-                  "offset": 286
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 13,
-              "column": 1,
-              "offset": 259
-            },
-            "end": {
-              "line": 13,
-              "column": 28,
-              "offset": 286
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "&",
-                  "position": {
-                    "start": {
-                      "line": 14,
-                      "column": 5,
-                      "offset": 291
-                    },
-                    "end": {
-                      "line": 14,
-                      "column": 10,
-                      "offset": 296
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "copycat ",
-                  "position": {
-                    "start": {
-                      "line": 14,
-                      "column": 10,
-                      "offset": 296
-                    },
-                    "end": {
-                      "line": 14,
-                      "column": 18,
-                      "offset": 304
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "&",
-                  "position": {
-                    "start": {
-                      "line": 14,
-                      "column": 18,
-                      "offset": 304
-                    },
-                    "end": {
-                      "line": 14,
-                      "column": 23,
-                      "offset": 309
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "amp; ",
-                  "position": {
-                    "start": {
-                      "line": 14,
-                      "column": 23,
-                      "offset": 309
-                    },
-                    "end": {
-                      "line": 14,
-                      "column": 28,
-                      "offset": 314
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "&",
-                  "position": {
-                    "start": {
-                      "line": 14,
-                      "column": 28,
-                      "offset": 314
-                    },
-                    "end": {
-                      "line": 14,
-                      "column": 33,
-                      "offset": 319
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "#x26",
-                  "position": {
-                    "start": {
-                      "line": 14,
-                      "column": 33,
-                      "offset": 319
-                    },
-                    "end": {
-                      "line": 14,
                       "column": 37,
-                      "offset": 323
+                      "offset": 314
                     },
                     "indent": []
                   }
@@ -744,14 +704,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 14,
+                  "line": 13,
                   "column": 5,
-                  "offset": 291
+                  "offset": 282
                 },
                 "end": {
-                  "line": 14,
+                  "line": 13,
                   "column": 37,
-                  "offset": 323
+                  "offset": 314
                 },
                 "indent": []
               }
@@ -759,14 +719,14 @@
           ],
           "position": {
             "start": {
-              "line": 14,
+              "line": 13,
               "column": 1,
-              "offset": 287
+              "offset": 278
             },
             "end": {
-              "line": 14,
+              "line": 13,
               "column": 37,
-              "offset": 323
+              "offset": 314
             },
             "indent": []
           }
@@ -784,14 +744,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 15,
+                      "line": 14,
                       "column": 5,
-                      "offset": 328
+                      "offset": 319
                     },
                     "end": {
-                      "line": 15,
+                      "line": 14,
                       "column": 16,
-                      "offset": 339
+                      "offset": 330
                     },
                     "indent": []
                   }
@@ -801,14 +761,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 15,
+                      "line": 14,
                       "column": 16,
-                      "offset": 339
+                      "offset": 330
                     },
                     "end": {
-                      "line": 15,
+                      "line": 14,
                       "column": 27,
-                      "offset": 350
+                      "offset": 341
                     },
                     "indent": []
                   }
@@ -818,14 +778,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 15,
+                      "line": 14,
                       "column": 27,
-                      "offset": 350
+                      "offset": 341
                     },
                     "end": {
-                      "line": 15,
+                      "line": 14,
                       "column": 43,
-                      "offset": 366
+                      "offset": 357
                     },
                     "indent": []
                   }
@@ -833,14 +793,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 15,
+                  "line": 14,
                   "column": 5,
-                  "offset": 328
+                  "offset": 319
                 },
                 "end": {
-                  "line": 15,
+                  "line": 14,
                   "column": 43,
-                  "offset": 366
+                  "offset": 357
                 },
                 "indent": []
               }
@@ -848,14 +808,14 @@
           ],
           "position": {
             "start": {
-              "line": 15,
+              "line": 14,
               "column": 1,
-              "offset": 324
+              "offset": 315
             },
             "end": {
-              "line": 15,
+              "line": 14,
               "column": 43,
-              "offset": 366
+              "offset": 357
             },
             "indent": []
           }
@@ -865,15 +825,14 @@
         "start": {
           "line": 13,
           "column": 1,
-          "offset": 259
+          "offset": 278
         },
         "end": {
-          "line": 15,
+          "line": 14,
           "column": 43,
-          "offset": 366
+          "offset": 357
         },
         "indent": [
-          1,
           1
         ]
       }
@@ -886,14 +845,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 17,
+              "line": 16,
               "column": 1,
-              "offset": 368
+              "offset": 359
             },
             "end": {
-              "line": 17,
+              "line": 16,
               "column": 63,
-              "offset": 430
+              "offset": 421
             },
             "indent": []
           }
@@ -901,14 +860,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 16,
           "column": 1,
-          "offset": 368
+          "offset": 359
         },
         "end": {
-          "line": 17,
+          "line": 16,
           "column": 63,
-          "offset": 430
+          "offset": 421
         },
         "indent": []
       }
@@ -926,14 +885,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 19,
+                  "line": 18,
                   "column": 2,
-                  "offset": 433
+                  "offset": 424
                 },
                 "end": {
-                  "line": 19,
+                  "line": 18,
                   "column": 5,
-                  "offset": 436
+                  "offset": 427
                 },
                 "indent": []
               }
@@ -941,14 +900,14 @@
           ],
           "position": {
             "start": {
-              "line": 19,
+              "line": 18,
               "column": 1,
-              "offset": 432
+              "offset": 423
             },
             "end": {
-              "line": 19,
+              "line": 18,
               "column": 6,
-              "offset": 437
+              "offset": 428
             },
             "indent": []
           }
@@ -958,14 +917,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 19,
+              "line": 18,
               "column": 6,
-              "offset": 437
+              "offset": 428
             },
             "end": {
-              "line": 19,
+              "line": 18,
               "column": 8,
-              "offset": 439
+              "offset": 430
             },
             "indent": []
           }
@@ -975,14 +934,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 19,
+              "line": 18,
               "column": 8,
-              "offset": 439
+              "offset": 430
             },
             "end": {
-              "line": 19,
+              "line": 18,
               "column": 13,
-              "offset": 444
+              "offset": 435
             },
             "indent": []
           }
@@ -990,14 +949,14 @@
       ],
       "position": {
         "start": {
-          "line": 19,
+          "line": 18,
           "column": 1,
-          "offset": 432
+          "offset": 423
         },
         "end": {
-          "line": 19,
+          "line": 18,
           "column": 13,
-          "offset": 444
+          "offset": 435
         },
         "indent": []
       }
@@ -1010,14 +969,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 21,
+              "line": 20,
               "column": 1,
-              "offset": 446
+              "offset": 437
             },
             "end": {
-              "line": 21,
+              "line": 20,
               "column": 53,
-              "offset": 498
+              "offset": 489
             },
             "indent": []
           }
@@ -1025,14 +984,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 20,
           "column": 1,
-          "offset": 446
+          "offset": 437
         },
         "end": {
-          "line": 21,
+          "line": 20,
           "column": 53,
-          "offset": 498
+          "offset": 489
         },
         "indent": []
       }
@@ -1045,14 +1004,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 23,
+              "line": 22,
               "column": 1,
-              "offset": 500
+              "offset": 491
             },
             "end": {
-              "line": 23,
+              "line": 22,
               "column": 3,
-              "offset": 502
+              "offset": 493
             },
             "indent": []
           }
@@ -1062,14 +1021,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 23,
+              "line": 22,
               "column": 3,
-              "offset": 502
+              "offset": 493
             },
             "end": {
-              "line": 24,
+              "line": 23,
               "column": 1,
-              "offset": 519
+              "offset": 510
             },
             "indent": [
               1
@@ -1081,14 +1040,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 24,
+              "line": 23,
               "column": 1,
-              "offset": 519
+              "offset": 510
             },
             "end": {
-              "line": 24,
+              "line": 23,
               "column": 3,
-              "offset": 521
+              "offset": 512
             },
             "indent": []
           }
@@ -1098,14 +1057,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 24,
+              "line": 23,
               "column": 3,
-              "offset": 521
+              "offset": 512
             },
             "end": {
-              "line": 25,
+              "line": 24,
               "column": 3,
-              "offset": 540
+              "offset": 531
             },
             "indent": [
               1
@@ -1117,14 +1076,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 25,
+              "line": 24,
               "column": 3,
-              "offset": 540
+              "offset": 531
             },
             "end": {
-              "line": 25,
+              "line": 24,
               "column": 5,
-              "offset": 542
+              "offset": 533
             },
             "indent": []
           }
@@ -1134,14 +1093,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 25,
+              "line": 24,
               "column": 5,
-              "offset": 542
+              "offset": 533
             },
             "end": {
-              "line": 25,
+              "line": 24,
               "column": 21,
-              "offset": 558
+              "offset": 549
             },
             "indent": []
           }
@@ -1149,14 +1108,14 @@
       ],
       "position": {
         "start": {
-          "line": 23,
+          "line": 22,
           "column": 1,
-          "offset": 500
+          "offset": 491
         },
         "end": {
-          "line": 25,
+          "line": 24,
           "column": 21,
-          "offset": 558
+          "offset": 549
         },
         "indent": [
           1,
@@ -1172,14 +1131,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 27,
+              "line": 26,
               "column": 1,
-              "offset": 560
+              "offset": 551
             },
             "end": {
-              "line": 27,
+              "line": 26,
               "column": 25,
-              "offset": 584
+              "offset": 575
             },
             "indent": []
           }
@@ -1187,14 +1146,14 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 26,
           "column": 1,
-          "offset": 560
+          "offset": 551
         },
         "end": {
-          "line": 27,
+          "line": 26,
           "column": 25,
-          "offset": 584
+          "offset": 575
         },
         "indent": []
       }
@@ -1207,14 +1166,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 29,
+              "line": 28,
               "column": 1,
-              "offset": 586
+              "offset": 577
             },
             "end": {
-              "line": 29,
+              "line": 28,
               "column": 3,
-              "offset": 588
+              "offset": 579
             },
             "indent": []
           }
@@ -1224,14 +1183,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 29,
+              "line": 28,
               "column": 3,
-              "offset": 588
+              "offset": 579
             },
             "end": {
-              "line": 29,
+              "line": 28,
               "column": 21,
-              "offset": 606
+              "offset": 597
             },
             "indent": []
           }
@@ -1239,14 +1198,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 28,
           "column": 1,
-          "offset": 586
+          "offset": 577
         },
         "end": {
-          "line": 29,
+          "line": 28,
           "column": 21,
-          "offset": 606
+          "offset": 597
         },
         "indent": []
       }
@@ -1259,14 +1218,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 31,
+              "line": 30,
               "column": 1,
-              "offset": 608
+              "offset": 599
             },
             "end": {
-              "line": 31,
+              "line": 30,
               "column": 16,
-              "offset": 623
+              "offset": 614
             },
             "indent": []
           }
@@ -1274,14 +1233,14 @@
       ],
       "position": {
         "start": {
-          "line": 31,
+          "line": 30,
           "column": 1,
-          "offset": 608
+          "offset": 599
         },
         "end": {
-          "line": 31,
+          "line": 30,
           "column": 16,
-          "offset": 623
+          "offset": 614
         },
         "indent": []
       }
@@ -1294,14 +1253,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 33,
+              "line": 32,
               "column": 1,
-              "offset": 625
+              "offset": 616
             },
             "end": {
-              "line": 33,
+              "line": 32,
               "column": 3,
-              "offset": 627
+              "offset": 618
             },
             "indent": []
           }
@@ -1311,14 +1270,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 33,
+              "line": 32,
               "column": 3,
-              "offset": 627
+              "offset": 618
             },
             "end": {
-              "line": 34,
+              "line": 33,
               "column": 3,
-              "offset": 644
+              "offset": 635
             },
             "indent": [
               1
@@ -1330,14 +1289,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 34,
+              "line": 33,
               "column": 3,
-              "offset": 644
+              "offset": 635
             },
             "end": {
-              "line": 34,
+              "line": 33,
               "column": 5,
-              "offset": 646
+              "offset": 637
             },
             "indent": []
           }
@@ -1347,14 +1306,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 34,
+              "line": 33,
               "column": 5,
-              "offset": 646
+              "offset": 637
             },
             "end": {
-              "line": 34,
+              "line": 33,
               "column": 23,
-              "offset": 664
+              "offset": 655
             },
             "indent": []
           }
@@ -1362,14 +1321,14 @@
       ],
       "position": {
         "start": {
-          "line": 33,
+          "line": 32,
           "column": 1,
-          "offset": 625
+          "offset": 616
         },
         "end": {
-          "line": 34,
+          "line": 33,
           "column": 23,
-          "offset": 664
+          "offset": 655
         },
         "indent": [
           1
@@ -1384,14 +1343,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 36,
+              "line": 35,
               "column": 1,
-              "offset": 666
+              "offset": 657
             },
             "end": {
-              "line": 36,
+              "line": 35,
               "column": 62,
-              "offset": 727
+              "offset": 718
             },
             "indent": []
           }
@@ -1399,14 +1358,14 @@
       ],
       "position": {
         "start": {
-          "line": 36,
+          "line": 35,
           "column": 1,
-          "offset": 666
+          "offset": 657
         },
         "end": {
-          "line": 36,
+          "line": 35,
           "column": 62,
-          "offset": 727
+          "offset": 718
         },
         "indent": []
       }
@@ -1435,14 +1394,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 37,
                           "column": 6,
-                          "offset": 734
+                          "offset": 725
                         },
                         "end": {
-                          "line": 38,
+                          "line": 37,
                           "column": 15,
-                          "offset": 743
+                          "offset": 734
                         },
                         "indent": []
                       }
@@ -1450,14 +1409,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 37,
                       "column": 5,
-                      "offset": 733
+                      "offset": 724
                     },
                     "end": {
-                      "line": 38,
+                      "line": 37,
                       "column": 16,
-                      "offset": 744
+                      "offset": 735
                     },
                     "indent": []
                   }
@@ -1465,14 +1424,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 37,
                   "column": 5,
-                  "offset": 733
+                  "offset": 724
                 },
                 "end": {
-                  "line": 38,
+                  "line": 37,
                   "column": 16,
-                  "offset": 744
+                  "offset": 735
                 },
                 "indent": []
               }
@@ -1480,14 +1439,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 37,
               "column": 1,
-              "offset": 729
+              "offset": 720
             },
             "end": {
-              "line": 38,
+              "line": 37,
               "column": 16,
-              "offset": 744
+              "offset": 735
             },
             "indent": []
           }
@@ -1510,14 +1469,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 38,
                           "column": 6,
-                          "offset": 750
+                          "offset": 741
                         },
                         "end": {
-                          "line": 39,
+                          "line": 38,
                           "column": 9,
-                          "offset": 753
+                          "offset": 744
                         },
                         "indent": []
                       }
@@ -1527,14 +1486,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 38,
                           "column": 9,
-                          "offset": 753
+                          "offset": 744
                         },
                         "end": {
-                          "line": 39,
+                          "line": 38,
                           "column": 11,
-                          "offset": 755
+                          "offset": 746
                         },
                         "indent": []
                       }
@@ -1544,14 +1503,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 38,
                           "column": 11,
-                          "offset": 755
+                          "offset": 746
                         },
                         "end": {
-                          "line": 39,
+                          "line": 38,
                           "column": 16,
-                          "offset": 760
+                          "offset": 751
                         },
                         "indent": []
                       }
@@ -1559,14 +1518,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 38,
                       "column": 5,
-                      "offset": 749
+                      "offset": 740
                     },
                     "end": {
-                      "line": 39,
+                      "line": 38,
                       "column": 17,
-                      "offset": 761
+                      "offset": 752
                     },
                     "indent": []
                   }
@@ -1574,14 +1533,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 38,
                   "column": 5,
-                  "offset": 749
+                  "offset": 740
                 },
                 "end": {
-                  "line": 39,
+                  "line": 38,
                   "column": 17,
-                  "offset": 761
+                  "offset": 752
                 },
                 "indent": []
               }
@@ -1589,14 +1548,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 38,
               "column": 1,
-              "offset": 745
+              "offset": 736
             },
             "end": {
-              "line": 39,
+              "line": 38,
               "column": 17,
-              "offset": 761
+              "offset": 752
             },
             "indent": []
           }
@@ -1619,14 +1578,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 39,
                           "column": 6,
-                          "offset": 767
+                          "offset": 758
                         },
                         "end": {
-                          "line": 40,
+                          "line": 39,
                           "column": 9,
-                          "offset": 770
+                          "offset": 761
                         },
                         "indent": []
                       }
@@ -1634,14 +1593,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 39,
                       "column": 5,
-                      "offset": 766
+                      "offset": 757
                     },
                     "end": {
-                      "line": 40,
+                      "line": 39,
                       "column": 10,
-                      "offset": 771
+                      "offset": 762
                     },
                     "indent": []
                   }
@@ -1649,14 +1608,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 39,
                   "column": 5,
-                  "offset": 766
+                  "offset": 757
                 },
                 "end": {
-                  "line": 40,
+                  "line": 39,
                   "column": 10,
-                  "offset": 771
+                  "offset": 762
                 },
                 "indent": []
               }
@@ -1664,14 +1623,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 39,
               "column": 1,
-              "offset": 762
+              "offset": 753
             },
             "end": {
-              "line": 40,
+              "line": 39,
               "column": 10,
-              "offset": 771
+              "offset": 762
             },
             "indent": []
           }
@@ -1694,14 +1653,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 40,
                           "column": 6,
-                          "offset": 777
+                          "offset": 768
                         },
                         "end": {
-                          "line": 41,
+                          "line": 40,
                           "column": 7,
-                          "offset": 778
+                          "offset": 769
                         },
                         "indent": []
                       }
@@ -1711,14 +1670,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 40,
                           "column": 7,
-                          "offset": 778
+                          "offset": 769
                         },
                         "end": {
-                          "line": 41,
+                          "line": 40,
                           "column": 9,
-                          "offset": 780
+                          "offset": 771
                         },
                         "indent": []
                       }
@@ -1728,14 +1687,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 40,
                           "column": 9,
-                          "offset": 780
+                          "offset": 771
                         },
                         "end": {
-                          "line": 41,
+                          "line": 40,
                           "column": 10,
-                          "offset": 781
+                          "offset": 772
                         },
                         "indent": []
                       }
@@ -1743,14 +1702,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 41,
+                      "line": 40,
                       "column": 5,
-                      "offset": 776
+                      "offset": 767
                     },
                     "end": {
-                      "line": 41,
+                      "line": 40,
                       "column": 11,
-                      "offset": 782
+                      "offset": 773
                     },
                     "indent": []
                   }
@@ -1758,14 +1717,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
+                  "line": 40,
                   "column": 5,
-                  "offset": 776
+                  "offset": 767
                 },
                 "end": {
-                  "line": 41,
+                  "line": 40,
                   "column": 11,
-                  "offset": 782
+                  "offset": 773
                 },
                 "indent": []
               }
@@ -1773,14 +1732,14 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 40,
               "column": 1,
-              "offset": 772
+              "offset": 763
             },
             "end": {
-              "line": 41,
+              "line": 40,
               "column": 11,
-              "offset": 782
+              "offset": 773
             },
             "indent": []
           }
@@ -1803,14 +1762,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 42,
+                          "line": 41,
                           "column": 6,
-                          "offset": 788
+                          "offset": 779
                         },
                         "end": {
-                          "line": 42,
+                          "line": 41,
                           "column": 7,
-                          "offset": 789
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1820,14 +1779,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 42,
+                          "line": 41,
                           "column": 7,
-                          "offset": 789
+                          "offset": 780
                         },
                         "end": {
-                          "line": 42,
+                          "line": 41,
                           "column": 9,
-                          "offset": 791
+                          "offset": 782
                         },
                         "indent": []
                       }
@@ -1837,14 +1796,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 42,
+                          "line": 41,
                           "column": 9,
-                          "offset": 791
+                          "offset": 782
                         },
                         "end": {
-                          "line": 42,
+                          "line": 41,
                           "column": 11,
-                          "offset": 793
+                          "offset": 784
                         },
                         "indent": []
                       }
@@ -1852,14 +1811,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 42,
+                      "line": 41,
                       "column": 5,
-                      "offset": 787
+                      "offset": 778
                     },
                     "end": {
-                      "line": 42,
+                      "line": 41,
                       "column": 12,
-                      "offset": 794
+                      "offset": 785
                     },
                     "indent": []
                   }
@@ -1867,14 +1826,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 42,
+                  "line": 41,
                   "column": 5,
-                  "offset": 787
+                  "offset": 778
                 },
                 "end": {
-                  "line": 42,
+                  "line": 41,
                   "column": 12,
-                  "offset": 794
+                  "offset": 785
                 },
                 "indent": []
               }
@@ -1882,14 +1841,14 @@
           ],
           "position": {
             "start": {
-              "line": 42,
+              "line": 41,
               "column": 1,
-              "offset": 783
+              "offset": 774
             },
             "end": {
-              "line": 42,
+              "line": 41,
               "column": 12,
-              "offset": 794
+              "offset": 785
             },
             "indent": []
           }
@@ -1912,14 +1871,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 43,
+                          "line": 42,
                           "column": 6,
-                          "offset": 800
+                          "offset": 791
                         },
                         "end": {
-                          "line": 43,
+                          "line": 42,
                           "column": 7,
-                          "offset": 801
+                          "offset": 792
                         },
                         "indent": []
                       }
@@ -1932,14 +1891,14 @@
                           "value": "a\\",
                           "position": {
                             "start": {
-                              "line": 43,
+                              "line": 42,
                               "column": 8,
-                              "offset": 802
+                              "offset": 793
                             },
                             "end": {
-                              "line": 43,
+                              "line": 42,
                               "column": 10,
-                              "offset": 804
+                              "offset": 795
                             },
                             "indent": []
                           }
@@ -1947,14 +1906,14 @@
                       ],
                       "position": {
                         "start": {
-                          "line": 43,
+                          "line": 42,
                           "column": 7,
-                          "offset": 801
+                          "offset": 792
                         },
                         "end": {
-                          "line": 43,
+                          "line": 42,
                           "column": 11,
-                          "offset": 805
+                          "offset": 796
                         },
                         "indent": []
                       }
@@ -1964,14 +1923,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 43,
+                          "line": 42,
                           "column": 11,
-                          "offset": 805
+                          "offset": 796
                         },
                         "end": {
-                          "line": 43,
+                          "line": 42,
                           "column": 12,
-                          "offset": 806
+                          "offset": 797
                         },
                         "indent": []
                       }
@@ -1979,14 +1938,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 43,
+                      "line": 42,
                       "column": 5,
-                      "offset": 799
+                      "offset": 790
                     },
                     "end": {
-                      "line": 43,
+                      "line": 42,
                       "column": 13,
-                      "offset": 807
+                      "offset": 798
                     },
                     "indent": []
                   }
@@ -1994,14 +1953,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 43,
+                  "line": 42,
                   "column": 5,
-                  "offset": 799
+                  "offset": 790
                 },
                 "end": {
-                  "line": 43,
+                  "line": 42,
                   "column": 13,
-                  "offset": 807
+                  "offset": 798
                 },
                 "indent": []
               }
@@ -2009,14 +1968,14 @@
           ],
           "position": {
             "start": {
-              "line": 43,
+              "line": 42,
               "column": 1,
-              "offset": 795
+              "offset": 786
             },
             "end": {
-              "line": 43,
+              "line": 42,
               "column": 13,
-              "offset": 807
+              "offset": 798
             },
             "indent": []
           }
@@ -2024,14 +1983,14 @@
       ],
       "position": {
         "start": {
-          "line": 38,
+          "line": 37,
           "column": 1,
-          "offset": 729
+          "offset": 720
         },
         "end": {
-          "line": 43,
+          "line": 42,
           "column": 13,
-          "offset": 807
+          "offset": 798
         },
         "indent": [
           1,
@@ -2053,14 +2012,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 45,
+                  "line": 44,
                   "column": 3,
-                  "offset": 811
+                  "offset": 802
                 },
                 "end": {
-                  "line": 45,
+                  "line": 44,
                   "column": 7,
-                  "offset": 815
+                  "offset": 806
                 },
                 "indent": []
               }
@@ -2068,14 +2027,14 @@
           ],
           "position": {
             "start": {
-              "line": 45,
+              "line": 44,
               "column": 1,
-              "offset": 809
+              "offset": 800
             },
             "end": {
-              "line": 45,
+              "line": 44,
               "column": 9,
-              "offset": 817
+              "offset": 808
             },
             "indent": []
           }
@@ -2083,14 +2042,14 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 44,
           "column": 1,
-          "offset": 809
+          "offset": 800
         },
         "end": {
-          "line": 45,
+          "line": 44,
           "column": 9,
-          "offset": 817
+          "offset": 808
         },
         "indent": []
       }
@@ -2103,14 +2062,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 47,
+              "line": 46,
               "column": 1,
-              "offset": 819
+              "offset": 810
             },
             "end": {
-              "line": 47,
+              "line": 46,
               "column": 33,
-              "offset": 851
+              "offset": 842
             },
             "indent": []
           }
@@ -2118,14 +2077,14 @@
       ],
       "position": {
         "start": {
-          "line": 47,
+          "line": 46,
           "column": 1,
-          "offset": 819
+          "offset": 810
         },
         "end": {
-          "line": 47,
+          "line": 46,
           "column": 33,
-          "offset": 851
+          "offset": 842
         },
         "indent": []
       }
@@ -2149,14 +2108,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 48,
                       "column": 5,
-                      "offset": 857
+                      "offset": 848
                     },
                     "end": {
-                      "line": 49,
+                      "line": 48,
                       "column": 9,
-                      "offset": 861
+                      "offset": 852
                     },
                     "indent": []
                   }
@@ -2166,14 +2125,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 48,
                       "column": 9,
-                      "offset": 861
+                      "offset": 852
                     },
                     "end": {
-                      "line": 49,
-                      "column": 11,
-                      "offset": 863
+                      "line": 48,
+                      "column": 15,
+                      "offset": 858
                     },
                     "indent": []
                   }
@@ -2183,14 +2142,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 49,
-                      "column": 11,
-                      "offset": 863
+                      "line": 48,
+                      "column": 15,
+                      "offset": 858
                     },
                     "end": {
-                      "line": 49,
-                      "column": 60,
-                      "offset": 912
+                      "line": 48,
+                      "column": 64,
+                      "offset": 907
                     },
                     "indent": []
                   }
@@ -2198,14 +2157,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 48,
                   "column": 5,
-                  "offset": 857
+                  "offset": 848
                 },
                 "end": {
-                  "line": 49,
-                  "column": 60,
-                  "offset": 912
+                  "line": 48,
+                  "column": 64,
+                  "offset": 907
                 },
                 "indent": []
               }
@@ -2213,14 +2172,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 48,
               "column": 1,
-              "offset": 853
+              "offset": 844
             },
             "end": {
-              "line": 49,
-              "column": 60,
-              "offset": 912
+              "line": 48,
+              "column": 64,
+              "offset": 907
             },
             "indent": []
           }
@@ -2238,31 +2197,31 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 49,
                       "column": 5,
+                      "offset": 912
+                    },
+                    "end": {
+                      "line": 49,
+                      "column": 10,
+                      "offset": 917
+                    },
+                    "indent": []
+                  }
+                },
+                {
+                  "type": "text",
+                  "value": ":",
+                  "position": {
+                    "start": {
+                      "line": 49,
+                      "column": 10,
                       "offset": 917
                     },
                     "end": {
-                      "line": 50,
-                      "column": 10,
-                      "offset": 922
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 50,
-                      "column": 10,
-                      "offset": 922
-                    },
-                    "end": {
-                      "line": 50,
-                      "column": 12,
-                      "offset": 924
+                      "line": 49,
+                      "column": 16,
+                      "offset": 923
                     },
                     "indent": []
                   }
@@ -2272,103 +2231,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 50,
-                      "column": 12,
-                      "offset": 924
-                    },
-                    "end": {
-                      "line": 50,
-                      "column": 61,
-                      "offset": 973
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 50,
-                  "column": 5,
-                  "offset": 917
-                },
-                "end": {
-                  "line": 50,
-                  "column": 61,
-                  "offset": 973
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 50,
-              "column": 1,
-              "offset": 913
-            },
-            "end": {
-              "line": 50,
-              "column": 61,
-              "offset": 973
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "http",
-                  "position": {
-                    "start": {
-                      "line": 51,
-                      "column": 5,
-                      "offset": 978
-                    },
-                    "end": {
-                      "line": 51,
-                      "column": 9,
-                      "offset": 982
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 51,
-                      "column": 9,
-                      "offset": 982
-                    },
-                    "end": {
-                      "line": 51,
+                      "line": 49,
                       "column": 16,
-                      "offset": 989
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "//user:password@host:port/path?key=value#fragment",
-                  "position": {
-                    "start": {
-                      "line": 51,
-                      "column": 16,
-                      "offset": 989
+                      "offset": 923
                     },
                     "end": {
-                      "line": 51,
+                      "line": 49,
                       "column": 65,
-                      "offset": 1038
+                      "offset": 972
                     },
                     "indent": []
                   }
@@ -2376,14 +2246,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 51,
+                  "line": 49,
                   "column": 5,
-                  "offset": 978
+                  "offset": 912
                 },
                 "end": {
-                  "line": 51,
+                  "line": 49,
                   "column": 65,
-                  "offset": 1038
+                  "offset": 972
                 },
                 "indent": []
               }
@@ -2391,103 +2261,14 @@
           ],
           "position": {
             "start": {
-              "line": 51,
+              "line": 49,
               "column": 1,
-              "offset": 974
+              "offset": 908
             },
             "end": {
-              "line": 51,
+              "line": 49,
               "column": 65,
-              "offset": 1038
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "https",
-                  "position": {
-                    "start": {
-                      "line": 52,
-                      "column": 5,
-                      "offset": 1043
-                    },
-                    "end": {
-                      "line": 52,
-                      "column": 10,
-                      "offset": 1048
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 52,
-                      "column": 10,
-                      "offset": 1048
-                    },
-                    "end": {
-                      "line": 52,
-                      "column": 17,
-                      "offset": 1055
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "//user:password@host:port/path?key=value#fragment",
-                  "position": {
-                    "start": {
-                      "line": 52,
-                      "column": 17,
-                      "offset": 1055
-                    },
-                    "end": {
-                      "line": 52,
-                      "column": 66,
-                      "offset": 1104
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 52,
-                  "column": 5,
-                  "offset": 1043
-                },
-                "end": {
-                  "line": 52,
-                  "column": 66,
-                  "offset": 1104
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 52,
-              "column": 1,
-              "offset": 1039
-            },
-            "end": {
-              "line": 52,
-              "column": 66,
-              "offset": 1104
+              "offset": 972
             },
             "indent": []
           }
@@ -2495,18 +2276,16 @@
       ],
       "position": {
         "start": {
-          "line": 49,
+          "line": 48,
           "column": 1,
-          "offset": 853
+          "offset": 844
         },
         "end": {
-          "line": 52,
-          "column": 66,
-          "offset": 1104
+          "line": 49,
+          "column": 65,
+          "offset": 972
         },
         "indent": [
-          1,
-          1,
           1
         ]
       }
@@ -2519,14 +2298,14 @@
           "value": "Double tildes should be ",
           "position": {
             "start": {
-              "line": 54,
+              "line": 51,
               "column": 1,
-              "offset": 1106
+              "offset": 974
             },
             "end": {
-              "line": 54,
+              "line": 51,
               "column": 25,
-              "offset": 1130
+              "offset": 998
             },
             "indent": []
           }
@@ -2536,14 +2315,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 54,
+              "line": 51,
               "column": 25,
-              "offset": 1130
+              "offset": 998
             },
             "end": {
-              "line": 54,
+              "line": 51,
               "column": 27,
-              "offset": 1132
+              "offset": 1000
             },
             "indent": []
           }
@@ -2553,14 +2332,14 @@
           "value": "~escaped",
           "position": {
             "start": {
-              "line": 54,
+              "line": 51,
               "column": 27,
-              "offset": 1132
+              "offset": 1000
             },
             "end": {
-              "line": 54,
+              "line": 51,
               "column": 35,
-              "offset": 1140
+              "offset": 1008
             },
             "indent": []
           }
@@ -2570,48 +2349,82 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 54,
+              "line": 51,
               "column": 35,
-              "offset": 1140
+              "offset": 1008
             },
             "end": {
-              "line": 54,
+              "line": 51,
               "column": 37,
-              "offset": 1142
+              "offset": 1010
             },
             "indent": []
           }
         },
         {
           "type": "text",
-          "value": "~.\nAnd here: foo~~.",
+          "value": "~.\nAnd here: foo",
           "position": {
             "start": {
-              "line": 54,
+              "line": 51,
               "column": 37,
-              "offset": 1142
+              "offset": 1010
             },
             "end": {
-              "line": 55,
-              "column": 17,
-              "offset": 1161
+              "line": 52,
+              "column": 14,
+              "offset": 1026
             },
             "indent": [
               1
             ]
           }
+        },
+        {
+          "type": "text",
+          "value": "~",
+          "position": {
+            "start": {
+              "line": 52,
+              "column": 14,
+              "offset": 1026
+            },
+            "end": {
+              "line": 52,
+              "column": 16,
+              "offset": 1028
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "~.",
+          "position": {
+            "start": {
+              "line": 52,
+              "column": 16,
+              "offset": 1028
+            },
+            "end": {
+              "line": 52,
+              "column": 18,
+              "offset": 1030
+            },
+            "indent": []
+          }
         }
       ],
       "position": {
         "start": {
-          "line": 54,
+          "line": 51,
           "column": 1,
-          "offset": 1106
+          "offset": 974
         },
         "end": {
-          "line": 55,
-          "column": 17,
-          "offset": 1161
+          "line": 52,
+          "column": 18,
+          "offset": 1030
         },
         "indent": [
           1
@@ -2626,14 +2439,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 57,
+              "line": 54,
               "column": 1,
-              "offset": 1163
+              "offset": 1032
             },
             "end": {
-              "line": 57,
+              "line": 54,
               "column": 36,
-              "offset": 1198
+              "offset": 1067
             },
             "indent": []
           }
@@ -2641,14 +2454,14 @@
       ],
       "position": {
         "start": {
-          "line": 57,
+          "line": 54,
           "column": 1,
-          "offset": 1163
+          "offset": 1032
         },
         "end": {
-          "line": 57,
+          "line": 54,
           "column": 36,
-          "offset": 1198
+          "offset": 1067
         },
         "indent": []
       }
@@ -2671,14 +2484,14 @@
                   "value": "here",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 56,
                       "column": 3,
-                      "offset": 1202
+                      "offset": 1071
                     },
                     "end": {
-                      "line": 59,
+                      "line": 56,
                       "column": 7,
-                      "offset": 1206
+                      "offset": 1075
                     },
                     "indent": []
                   }
@@ -2686,14 +2499,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 59,
+                  "line": 56,
                   "column": 3,
-                  "offset": 1202
+                  "offset": 1071
                 },
                 "end": {
-                  "line": 59,
+                  "line": 56,
                   "column": 9,
-                  "offset": 1208
+                  "offset": 1077
                 },
                 "indent": []
               }
@@ -2706,14 +2519,14 @@
                   "value": "they",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 56,
                       "column": 12,
-                      "offset": 1211
+                      "offset": 1080
                     },
                     "end": {
-                      "line": 59,
+                      "line": 56,
                       "column": 16,
-                      "offset": 1215
+                      "offset": 1084
                     },
                     "indent": []
                   }
@@ -2721,14 +2534,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 59,
+                  "line": 56,
                   "column": 12,
-                  "offset": 1211
+                  "offset": 1080
                 },
                 "end": {
-                  "line": 59,
+                  "line": 56,
                   "column": 20,
-                  "offset": 1219
+                  "offset": 1088
                 },
                 "indent": []
               }
@@ -2736,14 +2549,14 @@
           ],
           "position": {
             "start": {
-              "line": 59,
+              "line": 56,
               "column": 1,
-              "offset": 1200
+              "offset": 1069
             },
             "end": {
-              "line": 59,
+              "line": 56,
               "column": 22,
-              "offset": 1221
+              "offset": 1090
             },
             "indent": []
           }
@@ -2759,14 +2572,14 @@
                   "value": "should",
                   "position": {
                     "start": {
-                      "line": 61,
+                      "line": 58,
                       "column": 3,
-                      "offset": 1246
+                      "offset": 1115
                     },
                     "end": {
-                      "line": 61,
+                      "line": 58,
                       "column": 9,
-                      "offset": 1252
+                      "offset": 1121
                     },
                     "indent": []
                   }
@@ -2774,14 +2587,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 61,
+                  "line": 58,
                   "column": 3,
-                  "offset": 1246
+                  "offset": 1115
                 },
                 "end": {
-                  "line": 61,
+                  "line": 58,
                   "column": 9,
-                  "offset": 1252
+                  "offset": 1121
                 },
                 "indent": []
               }
@@ -2794,14 +2607,14 @@
                   "value": "tho",
                   "position": {
                     "start": {
-                      "line": 61,
+                      "line": 58,
                       "column": 12,
-                      "offset": 1255
+                      "offset": 1124
                     },
                     "end": {
-                      "line": 61,
+                      "line": 58,
                       "column": 15,
-                      "offset": 1258
+                      "offset": 1127
                     },
                     "indent": []
                   }
@@ -2811,14 +2624,14 @@
                   "value": "|",
                   "position": {
                     "start": {
-                      "line": 61,
+                      "line": 58,
                       "column": 15,
-                      "offset": 1258
+                      "offset": 1127
                     },
                     "end": {
-                      "line": 61,
+                      "line": 58,
                       "column": 17,
-                      "offset": 1260
+                      "offset": 1129
                     },
                     "indent": []
                   }
@@ -2828,14 +2641,14 @@
                   "value": "ugh",
                   "position": {
                     "start": {
-                      "line": 61,
+                      "line": 58,
                       "column": 17,
-                      "offset": 1260
+                      "offset": 1129
                     },
                     "end": {
-                      "line": 61,
+                      "line": 58,
                       "column": 20,
-                      "offset": 1263
+                      "offset": 1132
                     },
                     "indent": []
                   }
@@ -2843,14 +2656,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 61,
+                  "line": 58,
                   "column": 12,
-                  "offset": 1255
+                  "offset": 1124
                 },
                 "end": {
-                  "line": 61,
+                  "line": 58,
                   "column": 20,
-                  "offset": 1263
+                  "offset": 1132
                 },
                 "indent": []
               }
@@ -2858,14 +2671,14 @@
           ],
           "position": {
             "start": {
-              "line": 61,
+              "line": 58,
               "column": 1,
-              "offset": 1244
+              "offset": 1113
             },
             "end": {
-              "line": 61,
+              "line": 58,
               "column": 22,
-              "offset": 1265
+              "offset": 1134
             },
             "indent": []
           }
@@ -2873,14 +2686,14 @@
       ],
       "position": {
         "start": {
-          "line": 59,
+          "line": 56,
           "column": 1,
-          "offset": 1200
+          "offset": 1069
         },
         "end": {
-          "line": 61,
+          "line": 58,
           "column": 22,
-          "offset": 1265
+          "offset": 1134
         },
         "indent": [
           1,
@@ -2896,14 +2709,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 63,
+              "line": 60,
               "column": 1,
-              "offset": 1267
+              "offset": 1136
             },
             "end": {
-              "line": 63,
+              "line": 60,
               "column": 10,
-              "offset": 1276
+              "offset": 1145
             },
             "indent": []
           }
@@ -2911,14 +2724,14 @@
       ],
       "position": {
         "start": {
-          "line": 63,
+          "line": 60,
           "column": 1,
-          "offset": 1267
+          "offset": 1136
         },
         "end": {
-          "line": 63,
+          "line": 60,
           "column": 10,
-          "offset": 1276
+          "offset": 1145
         },
         "indent": []
       }
@@ -2931,14 +2744,14 @@
           "value": "| here   | they   |\n",
           "position": {
             "start": {
-              "line": 65,
+              "line": 62,
               "column": 1,
-              "offset": 1278
+              "offset": 1147
             },
             "end": {
-              "line": 66,
+              "line": 63,
               "column": 1,
-              "offset": 1298
+              "offset": 1167
             },
             "indent": [
               1
@@ -2950,14 +2763,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 66,
+              "line": 63,
               "column": 1,
-              "offset": 1298
+              "offset": 1167
             },
             "end": {
-              "line": 66,
+              "line": 63,
               "column": 3,
-              "offset": 1300
+              "offset": 1169
             },
             "indent": []
           }
@@ -2967,14 +2780,14 @@
           "value": " ---- ",
           "position": {
             "start": {
-              "line": 66,
+              "line": 63,
               "column": 3,
-              "offset": 1300
+              "offset": 1169
             },
             "end": {
-              "line": 66,
+              "line": 63,
               "column": 9,
-              "offset": 1306
+              "offset": 1175
             },
             "indent": []
           }
@@ -2984,14 +2797,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 66,
+              "line": 63,
               "column": 9,
-              "offset": 1306
+              "offset": 1175
             },
             "end": {
-              "line": 66,
+              "line": 63,
               "column": 11,
-              "offset": 1308
+              "offset": 1177
             },
             "indent": []
           }
@@ -3001,14 +2814,14 @@
           "value": " ----- ",
           "position": {
             "start": {
-              "line": 66,
+              "line": 63,
               "column": 11,
-              "offset": 1308
+              "offset": 1177
             },
             "end": {
-              "line": 66,
+              "line": 63,
               "column": 18,
-              "offset": 1315
+              "offset": 1184
             },
             "indent": []
           }
@@ -3018,14 +2831,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 66,
+              "line": 63,
               "column": 18,
-              "offset": 1315
+              "offset": 1184
             },
             "end": {
-              "line": 66,
+              "line": 63,
               "column": 20,
-              "offset": 1317
+              "offset": 1186
             },
             "indent": []
           }
@@ -3035,14 +2848,14 @@
           "value": "\n| should | though |",
           "position": {
             "start": {
-              "line": 66,
+              "line": 63,
               "column": 20,
-              "offset": 1317
+              "offset": 1186
             },
             "end": {
-              "line": 67,
+              "line": 64,
               "column": 20,
-              "offset": 1337
+              "offset": 1206
             },
             "indent": [
               1
@@ -3052,14 +2865,14 @@
       ],
       "position": {
         "start": {
-          "line": 65,
+          "line": 62,
           "column": 1,
-          "offset": 1278
+          "offset": 1147
         },
         "end": {
-          "line": 67,
+          "line": 64,
           "column": 20,
-          "offset": 1337
+          "offset": 1206
         },
         "indent": [
           1,
@@ -3075,14 +2888,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 69,
+              "line": 66,
               "column": 1,
-              "offset": 1339
+              "offset": 1208
             },
             "end": {
-              "line": 69,
+              "line": 66,
               "column": 10,
-              "offset": 1348
+              "offset": 1217
             },
             "indent": []
           }
@@ -3090,14 +2903,14 @@
       ],
       "position": {
         "start": {
-          "line": 69,
+          "line": 66,
           "column": 1,
-          "offset": 1339
+          "offset": 1208
         },
         "end": {
-          "line": 69,
+          "line": 66,
           "column": 10,
-          "offset": 1348
+          "offset": 1217
         },
         "indent": []
       }
@@ -3110,14 +2923,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 71,
+              "line": 68,
               "column": 1,
-              "offset": 1350
+              "offset": 1219
             },
             "end": {
-              "line": 72,
+              "line": 69,
               "column": 1,
-              "offset": 1364
+              "offset": 1233
             },
             "indent": [
               1
@@ -3129,14 +2942,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 72,
+              "line": 69,
               "column": 1,
-              "offset": 1364
+              "offset": 1233
             },
             "end": {
-              "line": 72,
+              "line": 69,
               "column": 3,
-              "offset": 1366
+              "offset": 1235
             },
             "indent": []
           }
@@ -3146,14 +2959,14 @@
           "value": "--- ",
           "position": {
             "start": {
-              "line": 72,
+              "line": 69,
               "column": 3,
-              "offset": 1366
+              "offset": 1235
             },
             "end": {
-              "line": 72,
+              "line": 69,
               "column": 7,
-              "offset": 1370
+              "offset": 1239
             },
             "indent": []
           }
@@ -3163,14 +2976,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 72,
+              "line": 69,
               "column": 7,
-              "offset": 1370
+              "offset": 1239
             },
             "end": {
-              "line": 72,
+              "line": 69,
               "column": 9,
-              "offset": 1372
+              "offset": 1241
             },
             "indent": []
           }
@@ -3180,14 +2993,14 @@
           "value": " ------\nshould | though",
           "position": {
             "start": {
-              "line": 72,
+              "line": 69,
               "column": 9,
-              "offset": 1372
+              "offset": 1241
             },
             "end": {
-              "line": 73,
+              "line": 70,
               "column": 16,
-              "offset": 1395
+              "offset": 1264
             },
             "indent": [
               1
@@ -3197,14 +3010,14 @@
       ],
       "position": {
         "start": {
-          "line": 71,
+          "line": 68,
           "column": 1,
-          "offset": 1350
+          "offset": 1219
         },
         "end": {
-          "line": 73,
+          "line": 70,
           "column": 16,
-          "offset": 1395
+          "offset": 1264
         },
         "indent": [
           1,
@@ -3223,14 +3036,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 75,
+                  "line": 72,
                   "column": 3,
-                  "offset": 1399
+                  "offset": 1268
                 },
                 "end": {
-                  "line": 75,
+                  "line": 72,
                   "column": 14,
-                  "offset": 1410
+                  "offset": 1279
                 },
                 "indent": []
               }
@@ -3238,14 +3051,14 @@
           ],
           "position": {
             "start": {
-              "line": 75,
+              "line": 72,
               "column": 1,
-              "offset": 1397
+              "offset": 1266
             },
             "end": {
-              "line": 75,
+              "line": 72,
               "column": 16,
-              "offset": 1412
+              "offset": 1281
             },
             "indent": []
           }
@@ -3253,14 +3066,14 @@
       ],
       "position": {
         "start": {
-          "line": 75,
+          "line": 72,
           "column": 1,
-          "offset": 1397
+          "offset": 1266
         },
         "end": {
-          "line": 75,
+          "line": 72,
           "column": 16,
-          "offset": 1412
+          "offset": 1281
         },
         "indent": []
       }
@@ -3273,14 +3086,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 77,
+              "line": 74,
               "column": 1,
-              "offset": 1414
+              "offset": 1283
             },
             "end": {
-              "line": 77,
+              "line": 74,
               "column": 38,
-              "offset": 1451
+              "offset": 1320
             },
             "indent": []
           }
@@ -3288,14 +3101,14 @@
       ],
       "position": {
         "start": {
-          "line": 77,
+          "line": 74,
           "column": 1,
-          "offset": 1414
+          "offset": 1283
         },
         "end": {
-          "line": 77,
+          "line": 74,
           "column": 38,
-          "offset": 1451
+          "offset": 1320
         },
         "indent": []
       }
@@ -3319,14 +3132,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 76,
                       "column": 5,
-                      "offset": 1457
+                      "offset": 1326
                     },
                     "end": {
-                      "line": 79,
-                      "column": 7,
-                      "offset": 1459
+                      "line": 76,
+                      "column": 9,
+                      "offset": 1330
                     },
                     "indent": []
                   }
@@ -3336,14 +3149,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 79,
-                      "column": 7,
-                      "offset": 1459
+                      "line": 76,
+                      "column": 9,
+                      "offset": 1330
                     },
                     "end": {
-                      "line": 79,
-                      "column": 11,
-                      "offset": 1463
+                      "line": 76,
+                      "column": 13,
+                      "offset": 1334
                     },
                     "indent": []
                   }
@@ -3353,14 +3166,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
-                      "column": 11,
-                      "offset": 1463
+                      "line": 76,
+                      "column": 13,
+                      "offset": 1334
                     },
                     "end": {
-                      "line": 79,
-                      "column": 13,
-                      "offset": 1465
+                      "line": 76,
+                      "column": 17,
+                      "offset": 1338
                     },
                     "indent": []
                   }
@@ -3370,226 +3183,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 79,
-                      "column": 13,
-                      "offset": 1465
-                    },
-                    "end": {
-                      "line": 79,
-                      "column": 18,
-                      "offset": 1470
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 79,
-                  "column": 5,
-                  "offset": 1457
-                },
-                "end": {
-                  "line": 79,
-                  "column": 18,
-                  "offset": 1470
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 79,
-              "column": 1,
-              "offset": 1453
-            },
-            "end": {
-              "line": 79,
-              "column": 18,
-              "offset": 1470
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 5,
-                      "offset": 1475
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 7,
-                      "offset": 1477
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "http",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 7,
-                      "offset": 1477
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 11,
-                      "offset": 1481
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": ":",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 11,
-                      "offset": 1481
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 13,
-                      "offset": 1483
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "google.com>",
-                  "position": {
-                    "start": {
-                      "line": 80,
-                      "column": 13,
-                      "offset": 1483
-                    },
-                    "end": {
-                      "line": 80,
-                      "column": 24,
-                      "offset": 1494
-                    },
-                    "indent": []
-                  }
-                }
-              ],
-              "position": {
-                "start": {
-                  "line": 80,
-                  "column": 5,
-                  "offset": 1475
-                },
-                "end": {
-                  "line": 80,
-                  "column": 24,
-                  "offset": 1494
-                },
-                "indent": []
-              }
-            }
-          ],
-          "position": {
-            "start": {
-              "line": 80,
-              "column": 1,
-              "offset": 1471
-            },
-            "end": {
-              "line": 80,
-              "column": 24,
-              "offset": 1494
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "listItem",
-          "loose": false,
-          "checked": null,
-          "children": [
-            {
-              "type": "paragraph",
-              "children": [
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 81,
-                      "column": 5,
-                      "offset": 1499
-                    },
-                    "end": {
-                      "line": 81,
-                      "column": 9,
-                      "offset": 1503
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "div>",
-                  "position": {
-                    "start": {
-                      "line": 81,
-                      "column": 9,
-                      "offset": 1503
-                    },
-                    "end": {
-                      "line": 81,
-                      "column": 13,
-                      "offset": 1507
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "<",
-                  "position": {
-                    "start": {
-                      "line": 81,
-                      "column": 13,
-                      "offset": 1507
-                    },
-                    "end": {
-                      "line": 81,
+                      "line": 76,
                       "column": 17,
-                      "offset": 1511
-                    },
-                    "indent": []
-                  }
-                },
-                {
-                  "type": "text",
-                  "value": "/div>",
-                  "position": {
-                    "start": {
-                      "line": 81,
-                      "column": 17,
-                      "offset": 1511
+                      "offset": 1338
                     },
                     "end": {
-                      "line": 81,
+                      "line": 76,
                       "column": 22,
-                      "offset": 1516
+                      "offset": 1343
                     },
                     "indent": []
                   }
@@ -3597,14 +3198,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 81,
+                  "line": 76,
                   "column": 5,
-                  "offset": 1499
+                  "offset": 1326
                 },
                 "end": {
-                  "line": 81,
+                  "line": 76,
                   "column": 22,
-                  "offset": 1516
+                  "offset": 1343
                 },
                 "indent": []
               }
@@ -3612,14 +3213,14 @@
           ],
           "position": {
             "start": {
-              "line": 81,
+              "line": 76,
               "column": 1,
-              "offset": 1495
+              "offset": 1322
             },
             "end": {
-              "line": 81,
+              "line": 76,
               "column": 22,
-              "offset": 1516
+              "offset": 1343
             },
             "indent": []
           }
@@ -3637,14 +3238,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 82,
+                      "line": 77,
                       "column": 5,
-                      "offset": 1521
+                      "offset": 1348
                     },
                     "end": {
-                      "line": 82,
+                      "line": 77,
                       "column": 9,
-                      "offset": 1525
+                      "offset": 1352
                     },
                     "indent": []
                   }
@@ -3654,14 +3255,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 82,
+                      "line": 77,
                       "column": 9,
-                      "offset": 1525
+                      "offset": 1352
                     },
                     "end": {
-                      "line": 82,
+                      "line": 77,
                       "column": 13,
-                      "offset": 1529
+                      "offset": 1356
                     },
                     "indent": []
                   }
@@ -3671,14 +3272,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 82,
+                      "line": 77,
                       "column": 13,
-                      "offset": 1529
+                      "offset": 1356
                     },
                     "end": {
-                      "line": 82,
-                      "column": 20,
-                      "offset": 1536
+                      "line": 77,
+                      "column": 19,
+                      "offset": 1362
                     },
                     "indent": []
                   }
@@ -3688,14 +3289,14 @@
                   "value": "google.com>",
                   "position": {
                     "start": {
-                      "line": 82,
-                      "column": 20,
-                      "offset": 1536
+                      "line": 77,
+                      "column": 19,
+                      "offset": 1362
                     },
                     "end": {
-                      "line": 82,
-                      "column": 31,
-                      "offset": 1547
+                      "line": 77,
+                      "column": 30,
+                      "offset": 1373
                     },
                     "indent": []
                   }
@@ -3703,14 +3304,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 82,
+                  "line": 77,
                   "column": 5,
-                  "offset": 1521
+                  "offset": 1348
                 },
                 "end": {
-                  "line": 82,
-                  "column": 31,
-                  "offset": 1547
+                  "line": 77,
+                  "column": 30,
+                  "offset": 1373
                 },
                 "indent": []
               }
@@ -3718,14 +3319,14 @@
           ],
           "position": {
             "start": {
-              "line": 82,
+              "line": 77,
               "column": 1,
-              "offset": 1517
+              "offset": 1344
             },
             "end": {
-              "line": 82,
-              "column": 31,
-              "offset": 1547
+              "line": 77,
+              "column": 30,
+              "offset": 1373
             },
             "indent": []
           }
@@ -3733,18 +3334,16 @@
       ],
       "position": {
         "start": {
-          "line": 79,
+          "line": 76,
           "column": 1,
-          "offset": 1453
+          "offset": 1322
         },
         "end": {
-          "line": 82,
-          "column": 31,
-          "offset": 1547
+          "line": 77,
+          "column": 30,
+          "offset": 1373
         },
         "indent": [
-          1,
-          1,
           1
         ]
       }
@@ -3757,9 +3356,9 @@
       "offset": 0
     },
     "end": {
-      "line": 83,
+      "line": 78,
       "column": 1,
-      "offset": 1548
+      "offset": 1374
     }
   }
 }

--- a/test/tree/stringify-escape.pedantic.json
+++ b/test/tree/stringify-escape.pedantic.json
@@ -157,40 +157,6 @@
             },
             "indent": []
           }
-        },
-        {
-          "type": "text",
-          "value": " ",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 12,
-              "offset": 58
-            },
-            "end": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "indent": []
-          }
-        },
-        {
-          "type": "text",
-          "value": "_",
-          "position": {
-            "start": {
-              "line": 3,
-              "column": 13,
-              "offset": 59
-            },
-            "end": {
-              "line": 3,
-              "column": 15,
-              "offset": 61
-            },
-            "indent": []
-          }
         }
       ],
       "position": {
@@ -201,8 +167,8 @@
         },
         "end": {
           "line": 3,
-          "column": 15,
-          "offset": 61
+          "column": 12,
+          "offset": 58
         },
         "indent": []
       }
@@ -217,12 +183,12 @@
             "start": {
               "line": 5,
               "column": 1,
-              "offset": 63
+              "offset": 60
             },
             "end": {
               "line": 5,
               "column": 27,
-              "offset": 89
+              "offset": 86
             },
             "indent": []
           }
@@ -232,12 +198,12 @@
         "start": {
           "line": 5,
           "column": 1,
-          "offset": 63
+          "offset": 60
         },
         "end": {
           "line": 5,
           "column": 27,
-          "offset": 89
+          "offset": 86
         },
         "indent": []
       }
@@ -252,12 +218,12 @@
             "start": {
               "line": 7,
               "column": 1,
-              "offset": 91
+              "offset": 88
             },
             "end": {
               "line": 7,
               "column": 25,
-              "offset": 115
+              "offset": 112
             },
             "indent": []
           }
@@ -267,12 +233,219 @@
         "start": {
           "line": 7,
           "column": 1,
-          "offset": 91
+          "offset": 88
         },
         "end": {
           "line": 7,
           "column": 25,
-          "offset": 115
+          "offset": 112
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Underscores are ",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 114
+            },
+            "end": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 17,
+              "offset": 130
+            },
+            "end": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "escaped",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 19,
+              "offset": 132
+            },
+            "end": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "_",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 26,
+              "offset": 139
+            },
+            "end": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": " unless they appear in",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 28,
+              "offset": 141
+            },
+            "end": {
+              "line": 9,
+              "column": 50,
+              "offset": 163
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "emphasis",
+          "children": [
+            {
+              "type": "text",
+              "value": "the",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 51,
+                  "offset": 164
+                },
+                "end": {
+                  "line": 9,
+                  "column": 54,
+                  "offset": 167
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 50,
+              "offset": 163
+            },
+            "end": {
+              "line": 9,
+              "column": 55,
+              "offset": 168
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "middle",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 55,
+              "offset": 168
+            },
+            "end": {
+              "line": 9,
+              "column": 61,
+              "offset": 174
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "emphasis",
+          "children": [
+            {
+              "type": "text",
+              "value": "of",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 62,
+                  "offset": 175
+                },
+                "end": {
+                  "line": 9,
+                  "column": 64,
+                  "offset": 177
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 61,
+              "offset": 174
+            },
+            "end": {
+              "line": 9,
+              "column": 65,
+              "offset": 178
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": "a_word.",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 65,
+              "offset": 178
+            },
+            "end": {
+              "line": 9,
+              "column": 72,
+              "offset": 185
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 114
+        },
+        "end": {
+          "line": 9,
+          "column": 72,
+          "offset": 185
         },
         "indent": []
       }
@@ -285,14 +458,14 @@
           "value": "Ampersands are escaped only when they would otherwise start an entity:",
           "position": {
             "start": {
-              "line": 9,
+              "line": 11,
               "column": 1,
-              "offset": 117
+              "offset": 187
             },
             "end": {
-              "line": 9,
+              "line": 11,
               "column": 71,
-              "offset": 187
+              "offset": 257
             },
             "indent": []
           }
@@ -300,14 +473,14 @@
       ],
       "position": {
         "start": {
-          "line": 9,
+          "line": 11,
           "column": 1,
-          "offset": 117
+          "offset": 187
         },
         "end": {
-          "line": 9,
+          "line": 11,
           "column": 71,
-          "offset": 187
+          "offset": 257
         },
         "indent": []
       }
@@ -331,14 +504,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 5,
-                      "offset": 193
+                      "offset": 263
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 6,
-                      "offset": 194
+                      "offset": 264
                     },
                     "indent": []
                   }
@@ -348,14 +521,14 @@
                   "value": "©",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 6,
-                      "offset": 194
+                      "offset": 264
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 11,
-                      "offset": 199
+                      "offset": 269
                     },
                     "indent": []
                   }
@@ -365,14 +538,14 @@
                   "value": "cat \\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 11,
-                      "offset": 199
+                      "offset": 269
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 16,
-                      "offset": 204
+                      "offset": 274
                     },
                     "indent": []
                   }
@@ -382,14 +555,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 16,
-                      "offset": 204
+                      "offset": 274
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 21,
-                      "offset": 209
+                      "offset": 279
                     },
                     "indent": []
                   }
@@ -399,14 +572,14 @@
                   "value": " \\",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 21,
-                      "offset": 209
+                      "offset": 279
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "indent": []
                   }
@@ -416,14 +589,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 11,
+                      "line": 13,
                       "column": 23,
-                      "offset": 211
+                      "offset": 281
                     },
                     "end": {
-                      "line": 11,
+                      "line": 13,
                       "column": 28,
-                      "offset": 216
+                      "offset": 286
                     },
                     "indent": []
                   }
@@ -431,14 +604,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 11,
+                  "line": 13,
                   "column": 5,
-                  "offset": 193
+                  "offset": 263
                 },
                 "end": {
-                  "line": 11,
+                  "line": 13,
                   "column": 28,
-                  "offset": 216
+                  "offset": 286
                 },
                 "indent": []
               }
@@ -446,14 +619,14 @@
           ],
           "position": {
             "start": {
-              "line": 11,
+              "line": 13,
               "column": 1,
-              "offset": 189
+              "offset": 259
             },
             "end": {
-              "line": 11,
+              "line": 13,
               "column": 28,
-              "offset": 216
+              "offset": 286
             },
             "indent": []
           }
@@ -471,14 +644,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 5,
-                      "offset": 221
+                      "offset": 291
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "indent": []
                   }
@@ -488,14 +661,14 @@
                   "value": "copycat ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 10,
-                      "offset": 226
+                      "offset": 296
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "indent": []
                   }
@@ -505,14 +678,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 18,
-                      "offset": 234
+                      "offset": 304
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "indent": []
                   }
@@ -522,14 +695,14 @@
                   "value": "amp; ",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 23,
-                      "offset": 239
+                      "offset": 309
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "indent": []
                   }
@@ -539,14 +712,14 @@
                   "value": "&",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 28,
-                      "offset": 244
+                      "offset": 314
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "indent": []
                   }
@@ -556,14 +729,14 @@
                   "value": "#x26",
                   "position": {
                     "start": {
-                      "line": 12,
+                      "line": 14,
                       "column": 33,
-                      "offset": 249
+                      "offset": 319
                     },
                     "end": {
-                      "line": 12,
+                      "line": 14,
                       "column": 37,
-                      "offset": 253
+                      "offset": 323
                     },
                     "indent": []
                   }
@@ -571,14 +744,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 12,
+                  "line": 14,
                   "column": 5,
-                  "offset": 221
+                  "offset": 291
                 },
                 "end": {
-                  "line": 12,
+                  "line": 14,
                   "column": 37,
-                  "offset": 253
+                  "offset": 323
                 },
                 "indent": []
               }
@@ -586,14 +759,14 @@
           ],
           "position": {
             "start": {
-              "line": 12,
+              "line": 14,
               "column": 1,
-              "offset": 217
+              "offset": 287
             },
             "end": {
-              "line": 12,
+              "line": 14,
               "column": 37,
-              "offset": 253
+              "offset": 323
             },
             "indent": []
           }
@@ -611,14 +784,14 @@
                   "value": "But: ©cat; ",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 5,
-                      "offset": 258
+                      "offset": 328
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "indent": []
                   }
@@ -628,14 +801,14 @@
                   "value": "&between;",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 16,
-                      "offset": 269
+                      "offset": 339
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "indent": []
                   }
@@ -645,14 +818,14 @@
                   "value": " &foo; & AT&T &c",
                   "position": {
                     "start": {
-                      "line": 13,
+                      "line": 15,
                       "column": 27,
-                      "offset": 280
+                      "offset": 350
                     },
                     "end": {
-                      "line": 13,
+                      "line": 15,
                       "column": 43,
-                      "offset": 296
+                      "offset": 366
                     },
                     "indent": []
                   }
@@ -660,14 +833,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 13,
+                  "line": 15,
                   "column": 5,
-                  "offset": 258
+                  "offset": 328
                 },
                 "end": {
-                  "line": 13,
+                  "line": 15,
                   "column": 43,
-                  "offset": 296
+                  "offset": 366
                 },
                 "indent": []
               }
@@ -675,14 +848,14 @@
           ],
           "position": {
             "start": {
-              "line": 13,
+              "line": 15,
               "column": 1,
-              "offset": 254
+              "offset": 324
             },
             "end": {
-              "line": 13,
+              "line": 15,
               "column": 43,
-              "offset": 296
+              "offset": 366
             },
             "indent": []
           }
@@ -690,14 +863,14 @@
       ],
       "position": {
         "start": {
-          "line": 11,
+          "line": 13,
           "column": 1,
-          "offset": 189
+          "offset": 259
         },
         "end": {
-          "line": 13,
+          "line": 15,
           "column": 43,
-          "offset": 296
+          "offset": 366
         },
         "indent": [
           1,
@@ -713,14 +886,14 @@
           "value": "Open parenthesis should be escaped after a shortcut reference:",
           "position": {
             "start": {
-              "line": 15,
+              "line": 17,
               "column": 1,
-              "offset": 298
+              "offset": 368
             },
             "end": {
-              "line": 15,
+              "line": 17,
               "column": 63,
-              "offset": 360
+              "offset": 430
             },
             "indent": []
           }
@@ -728,14 +901,14 @@
       ],
       "position": {
         "start": {
-          "line": 15,
+          "line": 17,
           "column": 1,
-          "offset": 298
+          "offset": 368
         },
         "end": {
-          "line": 15,
+          "line": 17,
           "column": 63,
-          "offset": 360
+          "offset": 430
         },
         "indent": []
       }
@@ -753,14 +926,14 @@
               "value": "ref",
               "position": {
                 "start": {
-                  "line": 17,
+                  "line": 19,
                   "column": 2,
-                  "offset": 363
+                  "offset": 433
                 },
                 "end": {
-                  "line": 17,
+                  "line": 19,
                   "column": 5,
-                  "offset": 366
+                  "offset": 436
                 },
                 "indent": []
               }
@@ -768,14 +941,14 @@
           ],
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 1,
-              "offset": 362
+              "offset": 432
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "indent": []
           }
@@ -785,14 +958,14 @@
           "value": "(",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 6,
-              "offset": 367
+              "offset": 437
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "indent": []
           }
@@ -802,14 +975,14 @@
           "value": "text)",
           "position": {
             "start": {
-              "line": 17,
+              "line": 19,
               "column": 8,
-              "offset": 369
+              "offset": 439
             },
             "end": {
-              "line": 17,
+              "line": 19,
               "column": 13,
-              "offset": 374
+              "offset": 444
             },
             "indent": []
           }
@@ -817,14 +990,14 @@
       ],
       "position": {
         "start": {
-          "line": 17,
+          "line": 19,
           "column": 1,
-          "offset": 362
+          "offset": 432
         },
         "end": {
-          "line": 17,
+          "line": 19,
           "column": 13,
-          "offset": 374
+          "offset": 444
         },
         "indent": []
       }
@@ -837,14 +1010,14 @@
           "value": "Hyphen should be escaped at the beginning of a line:",
           "position": {
             "start": {
-              "line": 19,
+              "line": 21,
               "column": 1,
-              "offset": 376
+              "offset": 446
             },
             "end": {
-              "line": 19,
+              "line": 21,
               "column": 53,
-              "offset": 428
+              "offset": 498
             },
             "indent": []
           }
@@ -852,14 +1025,14 @@
       ],
       "position": {
         "start": {
-          "line": 19,
+          "line": 21,
           "column": 1,
-          "offset": 376
+          "offset": 446
         },
         "end": {
-          "line": 19,
+          "line": 21,
           "column": 53,
-          "offset": 428
+          "offset": 498
         },
         "indent": []
       }
@@ -872,14 +1045,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 1,
-              "offset": 430
+              "offset": 500
             },
             "end": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "indent": []
           }
@@ -889,14 +1062,14 @@
           "value": " not a list item\n",
           "position": {
             "start": {
-              "line": 21,
+              "line": 23,
               "column": 3,
-              "offset": 432
+              "offset": 502
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "indent": [
               1
@@ -908,14 +1081,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 1,
-              "offset": 449
+              "offset": 519
             },
             "end": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "indent": []
           }
@@ -925,14 +1098,14 @@
           "value": " not a list item\n  ",
           "position": {
             "start": {
-              "line": 22,
+              "line": 24,
               "column": 3,
-              "offset": 451
+              "offset": 521
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "indent": [
               1
@@ -944,14 +1117,14 @@
           "value": "+",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 3,
-              "offset": 470
+              "offset": 540
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "indent": []
           }
@@ -961,14 +1134,14 @@
           "value": " not a list item",
           "position": {
             "start": {
-              "line": 23,
+              "line": 25,
               "column": 5,
-              "offset": 472
+              "offset": 542
             },
             "end": {
-              "line": 23,
+              "line": 25,
               "column": 21,
-              "offset": 488
+              "offset": 558
             },
             "indent": []
           }
@@ -976,14 +1149,14 @@
       ],
       "position": {
         "start": {
-          "line": 21,
+          "line": 23,
           "column": 1,
-          "offset": 430
+          "offset": 500
         },
         "end": {
-          "line": 23,
+          "line": 25,
           "column": 21,
-          "offset": 488
+          "offset": 558
         },
         "indent": [
           1,
@@ -999,14 +1172,14 @@
           "value": "Same for angle brackets:",
           "position": {
             "start": {
-              "line": 25,
+              "line": 27,
               "column": 1,
-              "offset": 490
+              "offset": 560
             },
             "end": {
-              "line": 25,
+              "line": 27,
               "column": 25,
-              "offset": 514
+              "offset": 584
             },
             "indent": []
           }
@@ -1014,14 +1187,14 @@
       ],
       "position": {
         "start": {
-          "line": 25,
+          "line": 27,
           "column": 1,
-          "offset": 490
+          "offset": 560
         },
         "end": {
-          "line": 25,
+          "line": 27,
           "column": 25,
-          "offset": 514
+          "offset": 584
         },
         "indent": []
       }
@@ -1034,14 +1207,14 @@
           "value": ">",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 1,
-              "offset": 516
+              "offset": 586
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "indent": []
           }
@@ -1051,14 +1224,14 @@
           "value": " not a block quote",
           "position": {
             "start": {
-              "line": 27,
+              "line": 29,
               "column": 3,
-              "offset": 518
+              "offset": 588
             },
             "end": {
-              "line": 27,
+              "line": 29,
               "column": 21,
-              "offset": 536
+              "offset": 606
             },
             "indent": []
           }
@@ -1066,14 +1239,14 @@
       ],
       "position": {
         "start": {
-          "line": 27,
+          "line": 29,
           "column": 1,
-          "offset": 516
+          "offset": 586
         },
         "end": {
-          "line": 27,
+          "line": 29,
           "column": 21,
-          "offset": 536
+          "offset": 606
         },
         "indent": []
       }
@@ -1086,14 +1259,14 @@
           "value": "And hash signs:",
           "position": {
             "start": {
-              "line": 29,
+              "line": 31,
               "column": 1,
-              "offset": 538
+              "offset": 608
             },
             "end": {
-              "line": 29,
+              "line": 31,
               "column": 16,
-              "offset": 553
+              "offset": 623
             },
             "indent": []
           }
@@ -1101,14 +1274,14 @@
       ],
       "position": {
         "start": {
-          "line": 29,
+          "line": 31,
           "column": 1,
-          "offset": 538
+          "offset": 608
         },
         "end": {
-          "line": 29,
+          "line": 31,
           "column": 16,
-          "offset": 553
+          "offset": 623
         },
         "indent": []
       }
@@ -1121,14 +1294,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 1,
-              "offset": 555
+              "offset": 625
             },
             "end": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "indent": []
           }
@@ -1138,14 +1311,14 @@
           "value": " not a heading\n  ",
           "position": {
             "start": {
-              "line": 31,
+              "line": 33,
               "column": 3,
-              "offset": 557
+              "offset": 627
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "indent": [
               1
@@ -1157,14 +1330,14 @@
           "value": "#",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 3,
-              "offset": 574
+              "offset": 644
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "indent": []
           }
@@ -1174,14 +1347,14 @@
           "value": "# not a subheading",
           "position": {
             "start": {
-              "line": 32,
+              "line": 34,
               "column": 5,
-              "offset": 576
+              "offset": 646
             },
             "end": {
-              "line": 32,
+              "line": 34,
               "column": 23,
-              "offset": 594
+              "offset": 664
             },
             "indent": []
           }
@@ -1189,14 +1362,14 @@
       ],
       "position": {
         "start": {
-          "line": 31,
+          "line": 33,
           "column": 1,
-          "offset": 555
+          "offset": 625
         },
         "end": {
-          "line": 32,
+          "line": 34,
           "column": 23,
-          "offset": 594
+          "offset": 664
         },
         "indent": [
           1
@@ -1211,14 +1384,14 @@
           "value": "Text under a shortcut reference should be preserved verbatim:",
           "position": {
             "start": {
-              "line": 34,
+              "line": 36,
               "column": 1,
-              "offset": 596
+              "offset": 666
             },
             "end": {
-              "line": 34,
+              "line": 36,
               "column": 62,
-              "offset": 657
+              "offset": 727
             },
             "indent": []
           }
@@ -1226,14 +1399,14 @@
       ],
       "position": {
         "start": {
-          "line": 34,
+          "line": 36,
           "column": 1,
-          "offset": 596
+          "offset": 666
         },
         "end": {
-          "line": 34,
+          "line": 36,
           "column": 62,
-          "offset": 657
+          "offset": 727
         },
         "indent": []
       }
@@ -1262,14 +1435,14 @@
                       "value": "two*three",
                       "position": {
                         "start": {
-                          "line": 36,
+                          "line": 38,
                           "column": 6,
-                          "offset": 664
+                          "offset": 734
                         },
                         "end": {
-                          "line": 36,
+                          "line": 38,
                           "column": 15,
-                          "offset": 673
+                          "offset": 743
                         },
                         "indent": []
                       }
@@ -1277,14 +1450,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 36,
+                      "line": 38,
                       "column": 5,
-                      "offset": 663
+                      "offset": 733
                     },
                     "end": {
-                      "line": 36,
+                      "line": 38,
                       "column": 16,
-                      "offset": 674
+                      "offset": 744
                     },
                     "indent": []
                   }
@@ -1292,14 +1465,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 36,
+                  "line": 38,
                   "column": 5,
-                  "offset": 663
+                  "offset": 733
                 },
                 "end": {
-                  "line": 36,
+                  "line": 38,
                   "column": 16,
-                  "offset": 674
+                  "offset": 744
                 },
                 "indent": []
               }
@@ -1307,14 +1480,14 @@
           ],
           "position": {
             "start": {
-              "line": 36,
+              "line": 38,
               "column": 1,
-              "offset": 659
+              "offset": 729
             },
             "end": {
-              "line": 36,
+              "line": 38,
               "column": 16,
-              "offset": 674
+              "offset": 744
             },
             "indent": []
           }
@@ -1337,14 +1510,14 @@
                       "value": "two",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 6,
-                          "offset": 680
+                          "offset": 750
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "indent": []
                       }
@@ -1354,14 +1527,14 @@
                       "value": "*",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 9,
-                          "offset": 683
+                          "offset": 753
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "indent": []
                       }
@@ -1371,14 +1544,14 @@
                       "value": "three",
                       "position": {
                         "start": {
-                          "line": 37,
+                          "line": 39,
                           "column": 11,
-                          "offset": 685
+                          "offset": 755
                         },
                         "end": {
-                          "line": 37,
+                          "line": 39,
                           "column": 16,
-                          "offset": 690
+                          "offset": 760
                         },
                         "indent": []
                       }
@@ -1386,14 +1559,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 37,
+                      "line": 39,
                       "column": 5,
-                      "offset": 679
+                      "offset": 749
                     },
                     "end": {
-                      "line": 37,
+                      "line": 39,
                       "column": 17,
-                      "offset": 691
+                      "offset": 761
                     },
                     "indent": []
                   }
@@ -1401,14 +1574,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 37,
+                  "line": 39,
                   "column": 5,
-                  "offset": 679
+                  "offset": 749
                 },
                 "end": {
-                  "line": 37,
+                  "line": 39,
                   "column": 17,
-                  "offset": 691
+                  "offset": 761
                 },
                 "indent": []
               }
@@ -1416,14 +1589,14 @@
           ],
           "position": {
             "start": {
-              "line": 37,
+              "line": 39,
               "column": 1,
-              "offset": 675
+              "offset": 745
             },
             "end": {
-              "line": 37,
+              "line": 39,
               "column": 17,
-              "offset": 691
+              "offset": 761
             },
             "indent": []
           }
@@ -1446,14 +1619,14 @@
                       "value": "a\\a",
                       "position": {
                         "start": {
-                          "line": 38,
+                          "line": 40,
                           "column": 6,
-                          "offset": 697
+                          "offset": 767
                         },
                         "end": {
-                          "line": 38,
+                          "line": 40,
                           "column": 9,
-                          "offset": 700
+                          "offset": 770
                         },
                         "indent": []
                       }
@@ -1461,14 +1634,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 38,
+                      "line": 40,
                       "column": 5,
-                      "offset": 696
+                      "offset": 766
                     },
                     "end": {
-                      "line": 38,
+                      "line": 40,
                       "column": 10,
-                      "offset": 701
+                      "offset": 771
                     },
                     "indent": []
                   }
@@ -1476,14 +1649,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 38,
+                  "line": 40,
                   "column": 5,
-                  "offset": 696
+                  "offset": 766
                 },
                 "end": {
-                  "line": 38,
+                  "line": 40,
                   "column": 10,
-                  "offset": 701
+                  "offset": 771
                 },
                 "indent": []
               }
@@ -1491,14 +1664,14 @@
           ],
           "position": {
             "start": {
-              "line": 38,
+              "line": 40,
               "column": 1,
-              "offset": 692
+              "offset": 762
             },
             "end": {
-              "line": 38,
+              "line": 40,
               "column": 10,
-              "offset": 701
+              "offset": 771
             },
             "indent": []
           }
@@ -1521,14 +1694,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 6,
-                          "offset": 707
+                          "offset": 777
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "indent": []
                       }
@@ -1538,14 +1711,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 7,
-                          "offset": 708
+                          "offset": 778
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "indent": []
                       }
@@ -1555,14 +1728,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 39,
+                          "line": 41,
                           "column": 9,
-                          "offset": 710
+                          "offset": 780
                         },
                         "end": {
-                          "line": 39,
+                          "line": 41,
                           "column": 10,
-                          "offset": 711
+                          "offset": 781
                         },
                         "indent": []
                       }
@@ -1570,14 +1743,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 39,
+                      "line": 41,
                       "column": 5,
-                      "offset": 706
+                      "offset": 776
                     },
                     "end": {
-                      "line": 39,
+                      "line": 41,
                       "column": 11,
-                      "offset": 712
+                      "offset": 782
                     },
                     "indent": []
                   }
@@ -1585,14 +1758,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 39,
+                  "line": 41,
                   "column": 5,
-                  "offset": 706
+                  "offset": 776
                 },
                 "end": {
-                  "line": 39,
+                  "line": 41,
                   "column": 11,
-                  "offset": 712
+                  "offset": 782
                 },
                 "indent": []
               }
@@ -1600,14 +1773,14 @@
           ],
           "position": {
             "start": {
-              "line": 39,
+              "line": 41,
               "column": 1,
-              "offset": 702
+              "offset": 772
             },
             "end": {
-              "line": 39,
+              "line": 41,
               "column": 11,
-              "offset": 712
+              "offset": 782
             },
             "indent": []
           }
@@ -1630,14 +1803,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 6,
-                          "offset": 718
+                          "offset": 788
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "indent": []
                       }
@@ -1647,14 +1820,14 @@
                       "value": "\\",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 7,
-                          "offset": 719
+                          "offset": 789
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "indent": []
                       }
@@ -1664,14 +1837,14 @@
                       "value": "\\a",
                       "position": {
                         "start": {
-                          "line": 40,
+                          "line": 42,
                           "column": 9,
-                          "offset": 721
+                          "offset": 791
                         },
                         "end": {
-                          "line": 40,
+                          "line": 42,
                           "column": 11,
-                          "offset": 723
+                          "offset": 793
                         },
                         "indent": []
                       }
@@ -1679,14 +1852,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 40,
+                      "line": 42,
                       "column": 5,
-                      "offset": 717
+                      "offset": 787
                     },
                     "end": {
-                      "line": 40,
+                      "line": 42,
                       "column": 12,
-                      "offset": 724
+                      "offset": 794
                     },
                     "indent": []
                   }
@@ -1694,14 +1867,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 40,
+                  "line": 42,
                   "column": 5,
-                  "offset": 717
+                  "offset": 787
                 },
                 "end": {
-                  "line": 40,
+                  "line": 42,
                   "column": 12,
-                  "offset": 724
+                  "offset": 794
                 },
                 "indent": []
               }
@@ -1709,14 +1882,14 @@
           ],
           "position": {
             "start": {
-              "line": 40,
+              "line": 42,
               "column": 1,
-              "offset": 713
+              "offset": 783
             },
             "end": {
-              "line": 40,
+              "line": 42,
               "column": 12,
-              "offset": 724
+              "offset": 794
             },
             "indent": []
           }
@@ -1739,14 +1912,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 6,
-                          "offset": 730
+                          "offset": 800
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 7,
-                          "offset": 731
+                          "offset": 801
                         },
                         "indent": []
                       }
@@ -1759,14 +1932,14 @@
                           "value": "a\\",
                           "position": {
                             "start": {
-                              "line": 41,
+                              "line": 43,
                               "column": 8,
-                              "offset": 732
+                              "offset": 802
                             },
                             "end": {
-                              "line": 41,
+                              "line": 43,
                               "column": 10,
-                              "offset": 734
+                              "offset": 804
                             },
                             "indent": []
                           }
@@ -1774,14 +1947,14 @@
                       ],
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 7,
-                          "offset": 731
+                          "offset": 801
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "indent": []
                       }
@@ -1791,14 +1964,14 @@
                       "value": "a",
                       "position": {
                         "start": {
-                          "line": 41,
+                          "line": 43,
                           "column": 11,
-                          "offset": 735
+                          "offset": 805
                         },
                         "end": {
-                          "line": 41,
+                          "line": 43,
                           "column": 12,
-                          "offset": 736
+                          "offset": 806
                         },
                         "indent": []
                       }
@@ -1806,14 +1979,14 @@
                   ],
                   "position": {
                     "start": {
-                      "line": 41,
+                      "line": 43,
                       "column": 5,
-                      "offset": 729
+                      "offset": 799
                     },
                     "end": {
-                      "line": 41,
+                      "line": 43,
                       "column": 13,
-                      "offset": 737
+                      "offset": 807
                     },
                     "indent": []
                   }
@@ -1821,14 +1994,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 41,
+                  "line": 43,
                   "column": 5,
-                  "offset": 729
+                  "offset": 799
                 },
                 "end": {
-                  "line": 41,
+                  "line": 43,
                   "column": 13,
-                  "offset": 737
+                  "offset": 807
                 },
                 "indent": []
               }
@@ -1836,14 +2009,14 @@
           ],
           "position": {
             "start": {
-              "line": 41,
+              "line": 43,
               "column": 1,
-              "offset": 725
+              "offset": 795
             },
             "end": {
-              "line": 41,
+              "line": 43,
               "column": 13,
-              "offset": 737
+              "offset": 807
             },
             "indent": []
           }
@@ -1851,14 +2024,14 @@
       ],
       "position": {
         "start": {
-          "line": 36,
+          "line": 38,
           "column": 1,
-          "offset": 659
+          "offset": 729
         },
         "end": {
-          "line": 41,
+          "line": 43,
           "column": 13,
-          "offset": 737
+          "offset": 807
         },
         "indent": [
           1,
@@ -1880,14 +2053,14 @@
               "value": "GFM:",
               "position": {
                 "start": {
-                  "line": 43,
+                  "line": 45,
                   "column": 3,
-                  "offset": 741
+                  "offset": 811
                 },
                 "end": {
-                  "line": 43,
+                  "line": 45,
                   "column": 7,
-                  "offset": 745
+                  "offset": 815
                 },
                 "indent": []
               }
@@ -1895,14 +2068,14 @@
           ],
           "position": {
             "start": {
-              "line": 43,
+              "line": 45,
               "column": 1,
-              "offset": 739
+              "offset": 809
             },
             "end": {
-              "line": 43,
+              "line": 45,
               "column": 9,
-              "offset": 747
+              "offset": 817
             },
             "indent": []
           }
@@ -1910,14 +2083,14 @@
       ],
       "position": {
         "start": {
-          "line": 43,
+          "line": 45,
           "column": 1,
-          "offset": 739
+          "offset": 809
         },
         "end": {
-          "line": 43,
+          "line": 45,
           "column": 9,
-          "offset": 747
+          "offset": 817
         },
         "indent": []
       }
@@ -1930,14 +2103,14 @@
           "value": "Colon should be escaped in URLs:",
           "position": {
             "start": {
-              "line": 45,
+              "line": 47,
               "column": 1,
-              "offset": 749
+              "offset": 819
             },
             "end": {
-              "line": 45,
+              "line": 47,
               "column": 33,
-              "offset": 781
+              "offset": 851
             },
             "indent": []
           }
@@ -1945,14 +2118,14 @@
       ],
       "position": {
         "start": {
-          "line": 45,
+          "line": 47,
           "column": 1,
-          "offset": 749
+          "offset": 819
         },
         "end": {
-          "line": 45,
+          "line": 47,
           "column": 33,
-          "offset": 781
+          "offset": 851
         },
         "indent": []
       }
@@ -1976,14 +2149,14 @@
                   "value": "http\\://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 47,
+                      "line": 49,
                       "column": 5,
-                      "offset": 787
+                      "offset": 857
                     },
                     "end": {
-                      "line": 47,
+                      "line": 49,
                       "column": 60,
-                      "offset": 842
+                      "offset": 912
                     },
                     "indent": []
                   }
@@ -1991,14 +2164,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 47,
+                  "line": 49,
                   "column": 5,
-                  "offset": 787
+                  "offset": 857
                 },
                 "end": {
-                  "line": 47,
+                  "line": 49,
                   "column": 60,
-                  "offset": 842
+                  "offset": 912
                 },
                 "indent": []
               }
@@ -2006,14 +2179,14 @@
           ],
           "position": {
             "start": {
-              "line": 47,
+              "line": 49,
               "column": 1,
-              "offset": 783
+              "offset": 853
             },
             "end": {
-              "line": 47,
+              "line": 49,
               "column": 60,
-              "offset": 842
+              "offset": 912
             },
             "indent": []
           }
@@ -2031,14 +2204,14 @@
                   "value": "https\\://user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 48,
+                      "line": 50,
                       "column": 5,
-                      "offset": 847
+                      "offset": 917
                     },
                     "end": {
-                      "line": 48,
+                      "line": 50,
                       "column": 61,
-                      "offset": 903
+                      "offset": 973
                     },
                     "indent": []
                   }
@@ -2046,14 +2219,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 48,
+                  "line": 50,
                   "column": 5,
-                  "offset": 847
+                  "offset": 917
                 },
                 "end": {
-                  "line": 48,
+                  "line": 50,
                   "column": 61,
-                  "offset": 903
+                  "offset": 973
                 },
                 "indent": []
               }
@@ -2061,14 +2234,14 @@
           ],
           "position": {
             "start": {
-              "line": 48,
+              "line": 50,
               "column": 1,
-              "offset": 843
+              "offset": 913
             },
             "end": {
-              "line": 48,
+              "line": 50,
               "column": 61,
-              "offset": 903
+              "offset": 973
             },
             "indent": []
           }
@@ -2086,14 +2259,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 5,
-                      "offset": 908
+                      "offset": 978
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "indent": []
                   }
@@ -2103,14 +2276,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 9,
-                      "offset": 912
+                      "offset": 982
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "indent": []
                   }
@@ -2120,14 +2293,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 49,
+                      "line": 51,
                       "column": 16,
-                      "offset": 919
+                      "offset": 989
                     },
                     "end": {
-                      "line": 49,
+                      "line": 51,
                       "column": 65,
-                      "offset": 968
+                      "offset": 1038
                     },
                     "indent": []
                   }
@@ -2135,14 +2308,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 49,
+                  "line": 51,
                   "column": 5,
-                  "offset": 908
+                  "offset": 978
                 },
                 "end": {
-                  "line": 49,
+                  "line": 51,
                   "column": 65,
-                  "offset": 968
+                  "offset": 1038
                 },
                 "indent": []
               }
@@ -2150,14 +2323,14 @@
           ],
           "position": {
             "start": {
-              "line": 49,
+              "line": 51,
               "column": 1,
-              "offset": 904
+              "offset": 974
             },
             "end": {
-              "line": 49,
+              "line": 51,
               "column": 65,
-              "offset": 968
+              "offset": 1038
             },
             "indent": []
           }
@@ -2175,14 +2348,14 @@
                   "value": "https",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 5,
-                      "offset": 973
+                      "offset": 1043
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "indent": []
                   }
@@ -2192,14 +2365,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 10,
-                      "offset": 978
+                      "offset": 1048
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "indent": []
                   }
@@ -2209,14 +2382,14 @@
                   "value": "//user:password@host:port/path?key=value#fragment",
                   "position": {
                     "start": {
-                      "line": 50,
+                      "line": 52,
                       "column": 17,
-                      "offset": 985
+                      "offset": 1055
                     },
                     "end": {
-                      "line": 50,
+                      "line": 52,
                       "column": 66,
-                      "offset": 1034
+                      "offset": 1104
                     },
                     "indent": []
                   }
@@ -2224,14 +2397,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 50,
+                  "line": 52,
                   "column": 5,
-                  "offset": 973
+                  "offset": 1043
                 },
                 "end": {
-                  "line": 50,
+                  "line": 52,
                   "column": 66,
-                  "offset": 1034
+                  "offset": 1104
                 },
                 "indent": []
               }
@@ -2239,14 +2412,14 @@
           ],
           "position": {
             "start": {
-              "line": 50,
+              "line": 52,
               "column": 1,
-              "offset": 969
+              "offset": 1039
             },
             "end": {
-              "line": 50,
+              "line": 52,
               "column": 66,
-              "offset": 1034
+              "offset": 1104
             },
             "indent": []
           }
@@ -2254,14 +2427,14 @@
       ],
       "position": {
         "start": {
-          "line": 47,
+          "line": 49,
           "column": 1,
-          "offset": 783
+          "offset": 853
         },
         "end": {
-          "line": 50,
+          "line": 52,
           "column": 66,
-          "offset": 1034
+          "offset": 1104
         },
         "indent": [
           1,
@@ -2278,14 +2451,14 @@
           "value": "Double tildes should be ",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 1,
-              "offset": 1036
+              "offset": 1106
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "indent": []
           }
@@ -2295,14 +2468,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 25,
-              "offset": 1060
+              "offset": 1130
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "indent": []
           }
@@ -2312,14 +2485,14 @@
           "value": "~escaped",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 27,
-              "offset": 1062
+              "offset": 1132
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "indent": []
           }
@@ -2329,14 +2502,14 @@
           "value": "~",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 35,
-              "offset": 1070
+              "offset": 1140
             },
             "end": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "indent": []
           }
@@ -2346,14 +2519,14 @@
           "value": "~.\nAnd here: foo~~.",
           "position": {
             "start": {
-              "line": 52,
+              "line": 54,
               "column": 37,
-              "offset": 1072
+              "offset": 1142
             },
             "end": {
-              "line": 53,
+              "line": 55,
               "column": 17,
-              "offset": 1091
+              "offset": 1161
             },
             "indent": [
               1
@@ -2363,14 +2536,14 @@
       ],
       "position": {
         "start": {
-          "line": 52,
+          "line": 54,
           "column": 1,
-          "offset": 1036
+          "offset": 1106
         },
         "end": {
-          "line": 53,
+          "line": 55,
           "column": 17,
-          "offset": 1091
+          "offset": 1161
         },
         "indent": [
           1
@@ -2385,14 +2558,14 @@
           "value": "Pipes should not be escaped here: |",
           "position": {
             "start": {
-              "line": 55,
+              "line": 57,
               "column": 1,
-              "offset": 1093
+              "offset": 1163
             },
             "end": {
-              "line": 55,
+              "line": 57,
               "column": 36,
-              "offset": 1128
+              "offset": 1198
             },
             "indent": []
           }
@@ -2400,14 +2573,14 @@
       ],
       "position": {
         "start": {
-          "line": 55,
+          "line": 57,
           "column": 1,
-          "offset": 1093
+          "offset": 1163
         },
         "end": {
-          "line": 55,
+          "line": 57,
           "column": 36,
-          "offset": 1128
+          "offset": 1198
         },
         "indent": []
       }
@@ -2430,14 +2603,14 @@
                   "value": "here",
                   "position": {
                     "start": {
-                      "line": 57,
+                      "line": 59,
                       "column": 3,
-                      "offset": 1132
+                      "offset": 1202
                     },
                     "end": {
-                      "line": 57,
+                      "line": 59,
                       "column": 7,
-                      "offset": 1136
+                      "offset": 1206
                     },
                     "indent": []
                   }
@@ -2445,14 +2618,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 57,
+                  "line": 59,
                   "column": 3,
-                  "offset": 1132
+                  "offset": 1202
                 },
                 "end": {
-                  "line": 57,
+                  "line": 59,
                   "column": 9,
-                  "offset": 1138
+                  "offset": 1208
                 },
                 "indent": []
               }
@@ -2465,14 +2638,14 @@
                   "value": "they",
                   "position": {
                     "start": {
-                      "line": 57,
+                      "line": 59,
                       "column": 12,
-                      "offset": 1141
+                      "offset": 1211
                     },
                     "end": {
-                      "line": 57,
+                      "line": 59,
                       "column": 16,
-                      "offset": 1145
+                      "offset": 1215
                     },
                     "indent": []
                   }
@@ -2480,14 +2653,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 57,
+                  "line": 59,
                   "column": 12,
-                  "offset": 1141
+                  "offset": 1211
                 },
                 "end": {
-                  "line": 57,
+                  "line": 59,
                   "column": 20,
-                  "offset": 1149
+                  "offset": 1219
                 },
                 "indent": []
               }
@@ -2495,14 +2668,14 @@
           ],
           "position": {
             "start": {
-              "line": 57,
+              "line": 59,
               "column": 1,
-              "offset": 1130
+              "offset": 1200
             },
             "end": {
-              "line": 57,
+              "line": 59,
               "column": 22,
-              "offset": 1151
+              "offset": 1221
             },
             "indent": []
           }
@@ -2518,14 +2691,14 @@
                   "value": "should",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 3,
-                      "offset": 1176
+                      "offset": 1246
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 9,
-                      "offset": 1182
+                      "offset": 1252
                     },
                     "indent": []
                   }
@@ -2533,14 +2706,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 59,
+                  "line": 61,
                   "column": 3,
-                  "offset": 1176
+                  "offset": 1246
                 },
                 "end": {
-                  "line": 59,
+                  "line": 61,
                   "column": 9,
-                  "offset": 1182
+                  "offset": 1252
                 },
                 "indent": []
               }
@@ -2553,14 +2726,14 @@
                   "value": "tho",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 12,
-                      "offset": 1185
+                      "offset": 1255
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 15,
-                      "offset": 1188
+                      "offset": 1258
                     },
                     "indent": []
                   }
@@ -2570,14 +2743,14 @@
                   "value": "|",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 15,
-                      "offset": 1188
+                      "offset": 1258
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 17,
-                      "offset": 1190
+                      "offset": 1260
                     },
                     "indent": []
                   }
@@ -2587,14 +2760,14 @@
                   "value": "ugh",
                   "position": {
                     "start": {
-                      "line": 59,
+                      "line": 61,
                       "column": 17,
-                      "offset": 1190
+                      "offset": 1260
                     },
                     "end": {
-                      "line": 59,
+                      "line": 61,
                       "column": 20,
-                      "offset": 1193
+                      "offset": 1263
                     },
                     "indent": []
                   }
@@ -2602,14 +2775,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 59,
+                  "line": 61,
                   "column": 12,
-                  "offset": 1185
+                  "offset": 1255
                 },
                 "end": {
-                  "line": 59,
+                  "line": 61,
                   "column": 20,
-                  "offset": 1193
+                  "offset": 1263
                 },
                 "indent": []
               }
@@ -2617,14 +2790,14 @@
           ],
           "position": {
             "start": {
-              "line": 59,
+              "line": 61,
               "column": 1,
-              "offset": 1174
+              "offset": 1244
             },
             "end": {
-              "line": 59,
+              "line": 61,
               "column": 22,
-              "offset": 1195
+              "offset": 1265
             },
             "indent": []
           }
@@ -2632,14 +2805,14 @@
       ],
       "position": {
         "start": {
-          "line": 57,
+          "line": 59,
           "column": 1,
-          "offset": 1130
+          "offset": 1200
         },
         "end": {
-          "line": 59,
+          "line": 61,
           "column": 22,
-          "offset": 1195
+          "offset": 1265
         },
         "indent": [
           1,
@@ -2655,14 +2828,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 61,
+              "line": 63,
               "column": 1,
-              "offset": 1197
+              "offset": 1267
             },
             "end": {
-              "line": 61,
+              "line": 63,
               "column": 10,
-              "offset": 1206
+              "offset": 1276
             },
             "indent": []
           }
@@ -2670,14 +2843,14 @@
       ],
       "position": {
         "start": {
-          "line": 61,
+          "line": 63,
           "column": 1,
-          "offset": 1197
+          "offset": 1267
         },
         "end": {
-          "line": 61,
+          "line": 63,
           "column": 10,
-          "offset": 1206
+          "offset": 1276
         },
         "indent": []
       }
@@ -2690,14 +2863,14 @@
           "value": "| here   | they   |\n",
           "position": {
             "start": {
-              "line": 63,
+              "line": 65,
               "column": 1,
-              "offset": 1208
+              "offset": 1278
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "indent": [
               1
@@ -2709,14 +2882,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 1,
-              "offset": 1228
+              "offset": 1298
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "indent": []
           }
@@ -2726,14 +2899,14 @@
           "value": " ---- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 3,
-              "offset": 1230
+              "offset": 1300
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "indent": []
           }
@@ -2743,14 +2916,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 9,
-              "offset": 1236
+              "offset": 1306
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "indent": []
           }
@@ -2760,14 +2933,14 @@
           "value": " ----- ",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 11,
-              "offset": 1238
+              "offset": 1308
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "indent": []
           }
@@ -2777,14 +2950,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 18,
-              "offset": 1245
+              "offset": 1315
             },
             "end": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "indent": []
           }
@@ -2794,14 +2967,14 @@
           "value": "\n| should | though |",
           "position": {
             "start": {
-              "line": 64,
+              "line": 66,
               "column": 20,
-              "offset": 1247
+              "offset": 1317
             },
             "end": {
-              "line": 65,
+              "line": 67,
               "column": 20,
-              "offset": 1267
+              "offset": 1337
             },
             "indent": [
               1
@@ -2811,14 +2984,14 @@
       ],
       "position": {
         "start": {
-          "line": 63,
+          "line": 65,
           "column": 1,
-          "offset": 1208
+          "offset": 1278
         },
         "end": {
-          "line": 65,
+          "line": 67,
           "column": 20,
-          "offset": 1267
+          "offset": 1337
         },
         "indent": [
           1,
@@ -2834,14 +3007,14 @@
           "value": "And here:",
           "position": {
             "start": {
-              "line": 67,
+              "line": 69,
               "column": 1,
-              "offset": 1269
+              "offset": 1339
             },
             "end": {
-              "line": 67,
+              "line": 69,
               "column": 10,
-              "offset": 1278
+              "offset": 1348
             },
             "indent": []
           }
@@ -2849,14 +3022,14 @@
       ],
       "position": {
         "start": {
-          "line": 67,
+          "line": 69,
           "column": 1,
-          "offset": 1269
+          "offset": 1339
         },
         "end": {
-          "line": 67,
+          "line": 69,
           "column": 10,
-          "offset": 1278
+          "offset": 1348
         },
         "indent": []
       }
@@ -2869,14 +3042,14 @@
           "value": "here   | they\n",
           "position": {
             "start": {
-              "line": 69,
+              "line": 71,
               "column": 1,
-              "offset": 1280
+              "offset": 1350
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "indent": [
               1
@@ -2888,14 +3061,14 @@
           "value": "-",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 1,
-              "offset": 1294
+              "offset": 1364
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "indent": []
           }
@@ -2905,14 +3078,14 @@
           "value": "--- ",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 3,
-              "offset": 1296
+              "offset": 1366
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "indent": []
           }
@@ -2922,14 +3095,14 @@
           "value": "|",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 7,
-              "offset": 1300
+              "offset": 1370
             },
             "end": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "indent": []
           }
@@ -2939,14 +3112,14 @@
           "value": " ------\nshould | though",
           "position": {
             "start": {
-              "line": 70,
+              "line": 72,
               "column": 9,
-              "offset": 1302
+              "offset": 1372
             },
             "end": {
-              "line": 71,
+              "line": 73,
               "column": 16,
-              "offset": 1325
+              "offset": 1395
             },
             "indent": [
               1
@@ -2956,14 +3129,14 @@
       ],
       "position": {
         "start": {
-          "line": 69,
+          "line": 71,
           "column": 1,
-          "offset": 1280
+          "offset": 1350
         },
         "end": {
-          "line": 71,
+          "line": 73,
           "column": 16,
-          "offset": 1325
+          "offset": 1395
         },
         "indent": [
           1,
@@ -2982,14 +3155,14 @@
               "value": "Commonmark:",
               "position": {
                 "start": {
-                  "line": 73,
+                  "line": 75,
                   "column": 3,
-                  "offset": 1329
+                  "offset": 1399
                 },
                 "end": {
-                  "line": 73,
+                  "line": 75,
                   "column": 14,
-                  "offset": 1340
+                  "offset": 1410
                 },
                 "indent": []
               }
@@ -2997,14 +3170,14 @@
           ],
           "position": {
             "start": {
-              "line": 73,
+              "line": 75,
               "column": 1,
-              "offset": 1327
+              "offset": 1397
             },
             "end": {
-              "line": 73,
+              "line": 75,
               "column": 16,
-              "offset": 1342
+              "offset": 1412
             },
             "indent": []
           }
@@ -3012,14 +3185,14 @@
       ],
       "position": {
         "start": {
-          "line": 73,
+          "line": 75,
           "column": 1,
-          "offset": 1327
+          "offset": 1397
         },
         "end": {
-          "line": 73,
+          "line": 75,
           "column": 16,
-          "offset": 1342
+          "offset": 1412
         },
         "indent": []
       }
@@ -3032,14 +3205,14 @@
           "value": "Open angle bracket should be escaped:",
           "position": {
             "start": {
-              "line": 75,
+              "line": 77,
               "column": 1,
-              "offset": 1344
+              "offset": 1414
             },
             "end": {
-              "line": 75,
+              "line": 77,
               "column": 38,
-              "offset": 1381
+              "offset": 1451
             },
             "indent": []
           }
@@ -3047,14 +3220,14 @@
       ],
       "position": {
         "start": {
-          "line": 75,
+          "line": 77,
           "column": 1,
-          "offset": 1344
+          "offset": 1414
         },
         "end": {
-          "line": 75,
+          "line": 77,
           "column": 38,
-          "offset": 1381
+          "offset": 1451
         },
         "indent": []
       }
@@ -3078,14 +3251,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 5,
-                      "offset": 1387
+                      "offset": 1457
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 6,
-                      "offset": 1388
+                      "offset": 1458
                     },
                     "indent": []
                   }
@@ -3095,14 +3268,14 @@
                   "value": "<div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 6,
-                      "offset": 1388
+                      "offset": 1458
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "indent": []
                   }
@@ -3112,14 +3285,14 @@
                   "value": "\\",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 11,
-                      "offset": 1393
+                      "offset": 1463
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 12,
-                      "offset": 1394
+                      "offset": 1464
                     },
                     "indent": []
                   }
@@ -3129,14 +3302,14 @@
                   "value": "</div>",
                   "position": {
                     "start": {
-                      "line": 77,
+                      "line": 79,
                       "column": 12,
-                      "offset": 1394
+                      "offset": 1464
                     },
                     "end": {
-                      "line": 77,
+                      "line": 79,
                       "column": 18,
-                      "offset": 1400
+                      "offset": 1470
                     },
                     "indent": []
                   }
@@ -3144,14 +3317,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 77,
+                  "line": 79,
                   "column": 5,
-                  "offset": 1387
+                  "offset": 1457
                 },
                 "end": {
-                  "line": 77,
+                  "line": 79,
                   "column": 18,
-                  "offset": 1400
+                  "offset": 1470
                 },
                 "indent": []
               }
@@ -3159,14 +3332,14 @@
           ],
           "position": {
             "start": {
-              "line": 77,
+              "line": 79,
               "column": 1,
-              "offset": 1383
+              "offset": 1453
             },
             "end": {
-              "line": 77,
+              "line": 79,
               "column": 18,
-              "offset": 1400
+              "offset": 1470
             },
             "indent": []
           }
@@ -3184,14 +3357,14 @@
                   "value": "\\<http\\:google.com>",
                   "position": {
                     "start": {
-                      "line": 78,
+                      "line": 80,
                       "column": 5,
-                      "offset": 1405
+                      "offset": 1475
                     },
                     "end": {
-                      "line": 78,
+                      "line": 80,
                       "column": 24,
-                      "offset": 1424
+                      "offset": 1494
                     },
                     "indent": []
                   }
@@ -3199,14 +3372,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 78,
+                  "line": 80,
                   "column": 5,
-                  "offset": 1405
+                  "offset": 1475
                 },
                 "end": {
-                  "line": 78,
+                  "line": 80,
                   "column": 24,
-                  "offset": 1424
+                  "offset": 1494
                 },
                 "indent": []
               }
@@ -3214,14 +3387,14 @@
           ],
           "position": {
             "start": {
-              "line": 78,
+              "line": 80,
               "column": 1,
-              "offset": 1401
+              "offset": 1471
             },
             "end": {
-              "line": 78,
+              "line": 80,
               "column": 24,
-              "offset": 1424
+              "offset": 1494
             },
             "indent": []
           }
@@ -3239,14 +3412,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 5,
-                      "offset": 1429
+                      "offset": 1499
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 9,
-                      "offset": 1433
+                      "offset": 1503
                     },
                     "indent": []
                   }
@@ -3256,14 +3429,14 @@
                   "value": "div>",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 9,
-                      "offset": 1433
+                      "offset": 1503
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 13,
-                      "offset": 1437
+                      "offset": 1507
                     },
                     "indent": []
                   }
@@ -3273,14 +3446,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 13,
-                      "offset": 1437
+                      "offset": 1507
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 17,
-                      "offset": 1441
+                      "offset": 1511
                     },
                     "indent": []
                   }
@@ -3290,14 +3463,14 @@
                   "value": "/div>",
                   "position": {
                     "start": {
-                      "line": 79,
+                      "line": 81,
                       "column": 17,
-                      "offset": 1441
+                      "offset": 1511
                     },
                     "end": {
-                      "line": 79,
+                      "line": 81,
                       "column": 22,
-                      "offset": 1446
+                      "offset": 1516
                     },
                     "indent": []
                   }
@@ -3305,14 +3478,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 79,
+                  "line": 81,
                   "column": 5,
-                  "offset": 1429
+                  "offset": 1499
                 },
                 "end": {
-                  "line": 79,
+                  "line": 81,
                   "column": 22,
-                  "offset": 1446
+                  "offset": 1516
                 },
                 "indent": []
               }
@@ -3320,14 +3493,14 @@
           ],
           "position": {
             "start": {
-              "line": 79,
+              "line": 81,
               "column": 1,
-              "offset": 1425
+              "offset": 1495
             },
             "end": {
-              "line": 79,
+              "line": 81,
               "column": 22,
-              "offset": 1446
+              "offset": 1516
             },
             "indent": []
           }
@@ -3345,14 +3518,14 @@
                   "value": "<",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 5,
-                      "offset": 1451
+                      "offset": 1521
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 9,
-                      "offset": 1455
+                      "offset": 1525
                     },
                     "indent": []
                   }
@@ -3362,14 +3535,14 @@
                   "value": "http",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 9,
-                      "offset": 1455
+                      "offset": 1525
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 13,
-                      "offset": 1459
+                      "offset": 1529
                     },
                     "indent": []
                   }
@@ -3379,14 +3552,14 @@
                   "value": ":",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 13,
-                      "offset": 1459
+                      "offset": 1529
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 20,
-                      "offset": 1466
+                      "offset": 1536
                     },
                     "indent": []
                   }
@@ -3396,14 +3569,14 @@
                   "value": "google.com>",
                   "position": {
                     "start": {
-                      "line": 80,
+                      "line": 82,
                       "column": 20,
-                      "offset": 1466
+                      "offset": 1536
                     },
                     "end": {
-                      "line": 80,
+                      "line": 82,
                       "column": 31,
-                      "offset": 1477
+                      "offset": 1547
                     },
                     "indent": []
                   }
@@ -3411,14 +3584,14 @@
               ],
               "position": {
                 "start": {
-                  "line": 80,
+                  "line": 82,
                   "column": 5,
-                  "offset": 1451
+                  "offset": 1521
                 },
                 "end": {
-                  "line": 80,
+                  "line": 82,
                   "column": 31,
-                  "offset": 1477
+                  "offset": 1547
                 },
                 "indent": []
               }
@@ -3426,14 +3599,14 @@
           ],
           "position": {
             "start": {
-              "line": 80,
+              "line": 82,
               "column": 1,
-              "offset": 1447
+              "offset": 1517
             },
             "end": {
-              "line": 80,
+              "line": 82,
               "column": 31,
-              "offset": 1477
+              "offset": 1547
             },
             "indent": []
           }
@@ -3441,14 +3614,14 @@
       ],
       "position": {
         "start": {
-          "line": 77,
+          "line": 79,
           "column": 1,
-          "offset": 1383
+          "offset": 1453
         },
         "end": {
-          "line": 80,
+          "line": 82,
           "column": 31,
-          "offset": 1477
+          "offset": 1547
         },
         "indent": [
           1,
@@ -3465,9 +3638,9 @@
       "offset": 0
     },
     "end": {
-      "line": 81,
+      "line": 83,
       "column": 1,
-      "offset": 1478
+      "offset": 1548
     }
   }
 }


### PR DESCRIPTION
This patch removes excessive escaping of underscore characters when surrounded by alphanumerics (not needed unless in pedantic mode).

Close #161.