### PR TITLE
Update links in error messages

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -63,7 +63,7 @@ var MIN_TABLE_ROWS = 2;
 var ERR_INFINITE_LOOP = 'Infinite loop';
 var ERR_MISSING_LOCATOR = 'Missing locator: ';
 var ERR_INCORRECTLY_EATEN = 'Incorrectly eaten value: please report this ' +
-    'warning on http://git.io/vUYWz';
+    'warning on http://git.io/vg5Ft';
 
 /*
  * Expressions.

--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -46,7 +46,7 @@ var YAML_FENCE_LENGTH = 3;
 var MINIMUM_RULE_LENGTH = 3;
 var MAILTO = 'mailto:';
 var ERROR_LIST_ITEM_INDENT = 'Cannot indent code properly. See ' +
-    'http://git.io/mdast-lii';
+    'http://git.io/vgFvT';
 
 /*
  * Expressions.

--- a/test/index.js
+++ b/test/index.js
@@ -743,7 +743,7 @@ describe('remark.process(value, options, done)', function () {
                     'pedantic': true,
                     'listItemIndent': '1'
                 });
-            }, /Cannot indent code properly. See http:\/\/git.io\/mdast-lii/);
+            }, /Cannot indent code properly. See http:\/\/git.io\/vgFvT/);
         }
     );
 });


### PR DESCRIPTION
Currently https://git.io/ links in error messages still redirect to [mdast](https://github.com/wooorm/mdast).

See wooorm/mdast#9.