### PR TITLE
Strip merged nodes from AST in compiler

### DIFF
--- a/lib/stringify.js
+++ b/lib/stringify.js
@@ -1007,6 +1007,7 @@ compilerPrototype.all = function (parent) {
     var values = [];
     var index = 0;
     var length = children.length;
+    var mergedLength = 1;
     var node = children[0];
     var next;
 
@@ -1027,10 +1028,12 @@ compilerPrototype.all = function (parent) {
         } else {
             values.push(self.visit(node, parent));
             node = next;
+            children[mergedLength++] = node;
         }
     }
 
     values.push(self.visit(node, parent));
+    children.length = mergedLength;
 
     return values;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1278,7 +1278,7 @@ describe('fixtures', function () {
 
                     compare(node, trees[mapping[key]], false, initialClean);
 
-                    markdown = remark.stringify(clone(node), stringify);
+                    markdown = remark.stringify(node, stringify);
                 });
 
                 if (output !== false) {


### PR DESCRIPTION
This patch removes AST nodes that are merged in compiler from the tree. Currently it is not the case, and so AST can be messed up during the process.

To illustrate the problem (see also https://github.com/wooorm/remark/pull/162#discussion_r52991739):

`ast`:

```json
{
  "type": "paragraph",
  "children": [
    {
      "type": "text",
      "value": "foo"
    },
    {
      "type": "text",
      "value": "bar"
    },
    {
      "type": "text",
      "value": "baz"
    }
  ]
}
```

```js
remark.stringify(ast);
```

`ast`:

```json
{
  "type": "paragraph",
  "children": [
    {
      "type": "text",
      "value": "foobarbaz"
    },
    {
      "type": "text",
      "value": "bar"
    },
    {
      "type": "text",
      "value": "baz"
    }
  ]
}
```