### PR TITLE
Fix parsing of 8-hashes

### DIFF
--- a/packages/remark-parse/lib/tokenize/heading-atx.js
+++ b/packages/remark-parse/lib/tokenize/heading-atx.js
@@ -55,7 +55,6 @@ function atxHeading(eat, value, silent) {
 
   /* Eat hashes. */
   depth = 0;
-  length = index + MAX_ATX_COUNT + 1;
 
   while (++index <= length) {
     character = value.charAt(index);
@@ -67,6 +66,9 @@ function atxHeading(eat, value, silent) {
 
     subvalue += character;
     depth++;
+  }
+  if (depth > MAX_ATX_COUNT) {
+    return;
   }
 
   if (

--- a/test/fixtures/input/heading-not-atx.text
+++ b/test/fixtures/input/heading-not-atx.text
@@ -1,3 +1,11 @@
 #This is not a heading, per CommonMark: <http://spec.commonmark.org/0.17/#example-25>
 
 Kramdown (GitHub) neither supports unspaced ATX-headings.
+
+######## h7?
+
+######### h8?
+
+########## h9?
+
+More than six # characters is not a heading: <http://spec.commonmark.org/0.26/#example-33>

--- a/test/fixtures/tree/heading-not-atx.json
+++ b/test/fixtures/tree/heading-not-atx.json
@@ -107,6 +107,183 @@
         },
         "indent": []
       }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "######## h7?",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1,
+              "offset": 146
+            },
+            "end": {
+              "line": 5,
+              "column": 13,
+              "offset": 158
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 146
+        },
+        "end": {
+          "line": 5,
+          "column": 13,
+          "offset": 158
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "######### h8?",
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 1,
+              "offset": 160
+            },
+            "end": {
+              "line": 7,
+              "column": 14,
+              "offset": 173
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 7,
+          "column": 1,
+          "offset": 160
+        },
+        "end": {
+          "line": 7,
+          "column": 14,
+          "offset": 173
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "########## h9?",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 175
+            },
+            "end": {
+              "line": 9,
+              "column": 15,
+              "offset": 189
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 175
+        },
+        "end": {
+          "line": 9,
+          "column": 15,
+          "offset": 189
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "More than six # characters is not a heading: ",
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1,
+              "offset": 191
+            },
+            "end": {
+              "line": 11,
+              "column": 46,
+              "offset": 236
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "link",
+          "title": null,
+          "url": "http://spec.commonmark.org/0.26/#example-33",
+          "children": [
+            {
+              "type": "text",
+              "value": "http://spec.commonmark.org/0.26/#example-33",
+              "position": {
+                "start": {
+                  "line": 11,
+                  "column": 47,
+                  "offset": 237
+                },
+                "end": {
+                  "line": 11,
+                  "column": 90,
+                  "offset": 280
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 46,
+              "offset": 236
+            },
+            "end": {
+              "line": 11,
+              "column": 91,
+              "offset": 281
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "offset": 191
+        },
+        "end": {
+          "line": 11,
+          "column": 91,
+          "offset": 281
+        },
+        "indent": []
+      }
     }
   ],
   "position": {
@@ -116,9 +293,9 @@
       "offset": 0
     },
     "end": {
-      "line": 4,
+      "line": 12,
       "column": 1,
-      "offset": 145
+      "offset": 282
     }
   }
 }

--- a/test/fixtures/tree/heading-not-atx.pedantic.json
+++ b/test/fixtures/tree/heading-not-atx.pedantic.json
@@ -108,6 +108,183 @@
         },
         "indent": []
       }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "######## h7?",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1,
+              "offset": 146
+            },
+            "end": {
+              "line": 5,
+              "column": 13,
+              "offset": 158
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 146
+        },
+        "end": {
+          "line": 5,
+          "column": 13,
+          "offset": 158
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "######### h8?",
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 1,
+              "offset": 160
+            },
+            "end": {
+              "line": 7,
+              "column": 14,
+              "offset": 173
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 7,
+          "column": 1,
+          "offset": 160
+        },
+        "end": {
+          "line": 7,
+          "column": 14,
+          "offset": 173
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "########## h9?",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 175
+            },
+            "end": {
+              "line": 9,
+              "column": 15,
+              "offset": 189
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 175
+        },
+        "end": {
+          "line": 9,
+          "column": 15,
+          "offset": 189
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "More than six # characters is not a heading: ",
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 1,
+              "offset": 191
+            },
+            "end": {
+              "line": 11,
+              "column": 46,
+              "offset": 236
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "link",
+          "title": null,
+          "url": "http://spec.commonmark.org/0.26/#example-33",
+          "children": [
+            {
+              "type": "text",
+              "value": "http://spec.commonmark.org/0.26/#example-33",
+              "position": {
+                "start": {
+                  "line": 11,
+                  "column": 47,
+                  "offset": 237
+                },
+                "end": {
+                  "line": 11,
+                  "column": 90,
+                  "offset": 280
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 11,
+              "column": 46,
+              "offset": 236
+            },
+            "end": {
+              "line": 11,
+              "column": 91,
+              "offset": 281
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 11,
+          "column": 1,
+          "offset": 191
+        },
+        "end": {
+          "line": 11,
+          "column": 91,
+          "offset": 281
+        },
+        "indent": []
+      }
     }
   ],
   "position": {
@@ -117,9 +294,9 @@
       "offset": 0
     },
     "end": {
-      "line": 4,
+      "line": 12,
       "column": 1,
-      "offset": 145
+      "offset": 282
     }
   }
 }


### PR DESCRIPTION
More than 6 `#`-es are not a heading.
Remark can parse 7, 9, and more `#`-es into a paragraph, but cannot parse exactly-8 `#`-es.

```js
const remark = require('remark');
const repeat = require('repeat-string');

for (const i of [6, 7, 8, 9]) {
  const input = `${repeat('#', i)} h${i}`;
  try {
    const output = remark().parse(input);
    console.log(JSON.stringify(output, null, 2));
  } catch (ex) {
    console.error(ex);
  }
}
```

* 6 hashes
  * Input: `###### h6`
  * Output: `<h6>h6</h6>`
* 7 hashes
  * Input: `####### h7`
  * Output: `<p>####### h7</p>`
* 8 hashes
  * Input: `######## h8`
  * Error:

    ```
    Error: Incorrectly eaten value: please report this warning on http://git.io/vg5Ft
      at validateEat (node_modules\remark-parse\lib\tokenizer.js:288:11)
      at eat (node_modules\remark-parse\lib\tokenizer.js:422:7)
      at Of.atxHeading (node_modules\remark-parse\lib\tokenize\heading-atx.js:152:10)
      at Of.tokenize [as tokenizeBlock] (node_modules\remark-parse\lib\tokenizer.js:148:18)
      at Of.parse (node_modules\remark-parse\lib\parse.js:54:20)
      at Function.parse (node_modules\unified\index.js:340:66)
    ```

* 9 hashes
  * Input: `######### h9`
  * Output: `<p>######### h9</p>`