### PR TITLE
Added paddedTable to remark-stringify

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -93,7 +93,7 @@ See [tools built with remark »][products].
     — [`Textr`](https://github.com/shuvalov-anton/textr), a modular typographic
     framework;
 *   [`RichardLitt/remark-title`](https://github.com/RichardLitt/remark-title)
-    - Check and inject the title of a markdown as the first element.
+    *   Check and inject the title of a markdown as the first element.
 *   [`wooorm/remark-toc`](https://github.com/wooorm/remark-toc)
     — Generate a Table of Contents (TOC) for Markdown files;
 *   [`eush77/remark-unlink`](https://github.com/eush77/remark-unlink)

--- a/packages/remark-stringify/lib/defaults.js
+++ b/packages/remark-stringify/lib/defaults.js
@@ -17,6 +17,7 @@ module.exports = {
   closeAtx: false,
   looseTable: false,
   spacedTable: true,
+  paddedTable: true,
   incrementListMarker: true,
   fences: false,
   fence: '`',

--- a/packages/remark-stringify/lib/visitors/table.js
+++ b/packages/remark-stringify/lib/visitors/table.js
@@ -42,6 +42,7 @@ function table(node) {
   var self = this;
   var loose = self.options.looseTable;
   var spaced = self.options.spacedTable;
+  var pad = self.options.paddedTable;
   var rows = node.children;
   var index = rows.length;
   var exit = self.enterTable();
@@ -66,6 +67,7 @@ function table(node) {
 
   return markdownTable(result, {
     align: node.align,
+    pad: pad,
     start: start,
     end: end,
     delimiter: spaced ? ' | ' : '|'

--- a/packages/remark-stringify/package.json
+++ b/packages/remark-stringify/package.json
@@ -33,7 +33,7 @@
     "is-whitespace-character": "^1.0.0",
     "longest-streak": "^2.0.1",
     "markdown-escapes": "^1.0.0",
-    "markdown-table": "^1.0.0",
+    "markdown-table": "^1.1.0",
     "mdast-util-compact": "^1.0.0",
     "parse-entities": "^1.0.2",
     "repeat-string": "^1.5.4",

--- a/packages/remark-stringify/readme.md
+++ b/packages/remark-stringify/readme.md
@@ -90,6 +90,8 @@ The following settings are supported:
     — Create tables without fences (initial and final pipes).
 *   `spacedTable` (`boolean`, default: `true`)
     — Create tables without spacing between pipes and content.
+*   `paddedTable` (`boolean`, default: `true`)
+    — Create tables with padding in each cell so that they are the same size.
 *   `fence` (`'~'` or ``'`'``, default: ``'`'``)
     — Fence marker to use for code blocks.
 *   `fences` (`boolean`, default: `false`)

--- a/test/remark-stringify.js
+++ b/test/remark-stringify.js
@@ -178,6 +178,14 @@ test('remark().stringify(ast, file, options?)', function (t) {
     'should throw when `options.spacedTable` is not a boolean'
   );
 
+  t.throws(
+    function () {
+      remark().stringify(empty(), {paddedTable: 'Not a boolean'});
+    },
+    /options\.paddedTable/,
+    'should throw when `options.paddedTable` is not a boolean'
+  );
+
   t.test('should be able to set options', function (st) {
     var processor = remark();
     var html = processor.Compiler.prototype.visitors.html;


### PR DESCRIPTION
@wooorm in reference to https://github.com/wooorm/markdown-table/pull/9#issuecomment-275703794

I'm not sure if `paddedTable` or `padTable` is better, but I just followed your convention from `looseTable` and `spacedTable`.

Heads up - this is a bigger project to wrap my head around, so I mostly just followed convention rather than trying to figure out what was actually going on. TBH I haven't even tested this against a real markdown file. That said, I think this works?
