### PR TITLE
Allow consecutive footnotes on a node in `remark-parse`

### DIFF
--- a/packages/remark-parse/lib/tokenize/reference.js
+++ b/packages/remark-parse/lib/tokenize/reference.js
@@ -122,7 +122,7 @@ function reference(eat, value, silent) {
 
   character = value.charAt(index);
 
-  if (character === C_BRACKET_OPEN) {
+  if ((self.options.footnotes && type !== T_FOOTNOTE) && character === C_BRACKET_OPEN) {
     identifier = '';
     queue += character;
     index++;

--- a/test/fixtures/input/footnote-consecutive.text
+++ b/test/fixtures/input/footnote-consecutive.text
@@ -1,0 +1,10 @@
+# International Radiotelephony Spelling Alphabet[^wiki]
+
+Here's the NATO phonetic alphabet[^wiki][^wiki2]: Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor[^name][^consecutive], Whiskey, X-ray, Yankee, and Zulu.
+
+And here's some more text.
+
+[^wiki]: Read more about it here.
+[^wiki2]: Here's another good article on the subject.
+[^name]: A great first name.
+[^consecutive]: I know.

--- a/test/fixtures/tree/footnote-consecutive.footnotes.json
+++ b/test/fixtures/tree/footnote-consecutive.footnotes.json
@@ -1,0 +1,458 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "International Radiotelephony Spelling Alphabet",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 3,
+              "offset": 2
+            },
+            "end": {
+              "line": 1,
+              "column": 49,
+              "offset": 48
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "wiki",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 49,
+              "offset": 48
+            },
+            "end": {
+              "line": 1,
+              "column": 56,
+              "offset": 55
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 56,
+          "offset": 55
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Here's the NATO phonetic alphabet",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1,
+              "offset": 57
+            },
+            "end": {
+              "line": 3,
+              "column": 34,
+              "offset": 90
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "wiki",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 34,
+              "offset": 90
+            },
+            "end": {
+              "line": 3,
+              "column": 41,
+              "offset": 97
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "wiki2",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 41,
+              "offset": 97
+            },
+            "end": {
+              "line": 3,
+              "column": 49,
+              "offset": 105
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ": Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 49,
+              "offset": 105
+            },
+            "end": {
+              "line": 3,
+              "column": 209,
+              "offset": 265
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "name",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 209,
+              "offset": 265
+            },
+            "end": {
+              "line": 3,
+              "column": 216,
+              "offset": 272
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "consecutive",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 216,
+              "offset": 272
+            },
+            "end": {
+              "line": 3,
+              "column": 230,
+              "offset": 286
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", Whiskey, X-ray, Yankee, and Zulu.",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 230,
+              "offset": 286
+            },
+            "end": {
+              "line": 3,
+              "column": 265,
+              "offset": 321
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1,
+          "offset": 57
+        },
+        "end": {
+          "line": 3,
+          "column": 265,
+          "offset": 321
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "And here's some more text.",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1,
+              "offset": 323
+            },
+            "end": {
+              "line": 5,
+              "column": 27,
+              "offset": 349
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 323
+        },
+        "end": {
+          "line": 5,
+          "column": 27,
+          "offset": 349
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "footnoteDefinition",
+      "identifier": "wiki",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Read more about it here.",
+              "position": {
+                "start": {
+                  "line": 7,
+                  "column": 10,
+                  "offset": 360
+                },
+                "end": {
+                  "line": 7,
+                  "column": 34,
+                  "offset": 384
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 10,
+              "offset": 360
+            },
+            "end": {
+              "line": 7,
+              "column": 34,
+              "offset": 384
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 7,
+          "column": 1,
+          "offset": 351
+        },
+        "end": {
+          "line": 7,
+          "column": 34,
+          "offset": 384
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "footnoteDefinition",
+      "identifier": "wiki2",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Here's another good article on the subject.",
+              "position": {
+                "start": {
+                  "line": 8,
+                  "column": 11,
+                  "offset": 395
+                },
+                "end": {
+                  "line": 8,
+                  "column": 54,
+                  "offset": 438
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 8,
+              "column": 11,
+              "offset": 395
+            },
+            "end": {
+              "line": 8,
+              "column": 54,
+              "offset": 438
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 8,
+          "column": 1,
+          "offset": 385
+        },
+        "end": {
+          "line": 8,
+          "column": 54,
+          "offset": 438
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "footnoteDefinition",
+      "identifier": "name",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "A great first name.",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 10,
+                  "offset": 448
+                },
+                "end": {
+                  "line": 9,
+                  "column": 29,
+                  "offset": 467
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 10,
+              "offset": 448
+            },
+            "end": {
+              "line": 9,
+              "column": 29,
+              "offset": 467
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 439
+        },
+        "end": {
+          "line": 9,
+          "column": 29,
+          "offset": 467
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "footnoteDefinition",
+      "identifier": "consecutive",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "I know.",
+              "position": {
+                "start": {
+                  "line": 10,
+                  "column": 17,
+                  "offset": 484
+                },
+                "end": {
+                  "line": 10,
+                  "column": 24,
+                  "offset": 491
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 10,
+              "column": 17,
+              "offset": 484
+            },
+            "end": {
+              "line": 10,
+              "column": 24,
+              "offset": 491
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 10,
+          "column": 1,
+          "offset": 468
+        },
+        "end": {
+          "line": 10,
+          "column": 24,
+          "offset": 491
+        },
+        "indent": []
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 1,
+      "offset": 492
+    }
+  }
+}

--- a/test/fixtures/tree/footnote-consecutive.footnotes.pedantic.json
+++ b/test/fixtures/tree/footnote-consecutive.footnotes.pedantic.json
@@ -1,0 +1,458 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "International Radiotelephony Spelling Alphabet",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 3,
+              "offset": 2
+            },
+            "end": {
+              "line": 1,
+              "column": 49,
+              "offset": 48
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "wiki",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 49,
+              "offset": 48
+            },
+            "end": {
+              "line": 1,
+              "column": 56,
+              "offset": 55
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 56,
+          "offset": 55
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Here's the NATO phonetic alphabet",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1,
+              "offset": 57
+            },
+            "end": {
+              "line": 3,
+              "column": 34,
+              "offset": 90
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "wiki",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 34,
+              "offset": 90
+            },
+            "end": {
+              "line": 3,
+              "column": 41,
+              "offset": 97
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "wiki2",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 41,
+              "offset": 97
+            },
+            "end": {
+              "line": 3,
+              "column": 49,
+              "offset": 105
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ": Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 49,
+              "offset": 105
+            },
+            "end": {
+              "line": 3,
+              "column": 209,
+              "offset": 265
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "name",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 209,
+              "offset": 265
+            },
+            "end": {
+              "line": 3,
+              "column": 216,
+              "offset": 272
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "footnoteReference",
+          "identifier": "consecutive",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 216,
+              "offset": 272
+            },
+            "end": {
+              "line": 3,
+              "column": 230,
+              "offset": 286
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", Whiskey, X-ray, Yankee, and Zulu.",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 230,
+              "offset": 286
+            },
+            "end": {
+              "line": 3,
+              "column": 265,
+              "offset": 321
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1,
+          "offset": 57
+        },
+        "end": {
+          "line": 3,
+          "column": 265,
+          "offset": 321
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "And here's some more text.",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1,
+              "offset": 323
+            },
+            "end": {
+              "line": 5,
+              "column": 27,
+              "offset": 349
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 323
+        },
+        "end": {
+          "line": 5,
+          "column": 27,
+          "offset": 349
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "footnoteDefinition",
+      "identifier": "wiki",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Read more about it here.",
+              "position": {
+                "start": {
+                  "line": 7,
+                  "column": 10,
+                  "offset": 360
+                },
+                "end": {
+                  "line": 7,
+                  "column": 34,
+                  "offset": 384
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 10,
+              "offset": 360
+            },
+            "end": {
+              "line": 7,
+              "column": 34,
+              "offset": 384
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 7,
+          "column": 1,
+          "offset": 351
+        },
+        "end": {
+          "line": 7,
+          "column": 34,
+          "offset": 384
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "footnoteDefinition",
+      "identifier": "wiki2",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "Here's another good article on the subject.",
+              "position": {
+                "start": {
+                  "line": 8,
+                  "column": 11,
+                  "offset": 395
+                },
+                "end": {
+                  "line": 8,
+                  "column": 54,
+                  "offset": 438
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 8,
+              "column": 11,
+              "offset": 395
+            },
+            "end": {
+              "line": 8,
+              "column": 54,
+              "offset": 438
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 8,
+          "column": 1,
+          "offset": 385
+        },
+        "end": {
+          "line": 8,
+          "column": 54,
+          "offset": 438
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "footnoteDefinition",
+      "identifier": "name",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "A great first name.",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 10,
+                  "offset": 448
+                },
+                "end": {
+                  "line": 9,
+                  "column": 29,
+                  "offset": 467
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 10,
+              "offset": 448
+            },
+            "end": {
+              "line": 9,
+              "column": 29,
+              "offset": 467
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 9,
+          "column": 1,
+          "offset": 439
+        },
+        "end": {
+          "line": 9,
+          "column": 29,
+          "offset": 467
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "footnoteDefinition",
+      "identifier": "consecutive",
+      "children": [
+        {
+          "type": "paragraph",
+          "children": [
+            {
+              "type": "text",
+              "value": "I know.",
+              "position": {
+                "start": {
+                  "line": 10,
+                  "column": 17,
+                  "offset": 484
+                },
+                "end": {
+                  "line": 10,
+                  "column": 24,
+                  "offset": 491
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 10,
+              "column": 17,
+              "offset": 484
+            },
+            "end": {
+              "line": 10,
+              "column": 24,
+              "offset": 491
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 10,
+          "column": 1,
+          "offset": 468
+        },
+        "end": {
+          "line": 10,
+          "column": 24,
+          "offset": 491
+        },
+        "indent": []
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 1,
+      "offset": 492
+    }
+  }
+}

--- a/test/fixtures/tree/footnote-consecutive.json
+++ b/test/fixtures/tree/footnote-consecutive.json
@@ -1,0 +1,586 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "heading",
+      "depth": 1,
+      "children": [
+        {
+          "type": "text",
+          "value": "International Radiotelephony Spelling Alphabet",
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 3,
+              "offset": 2
+            },
+            "end": {
+              "line": 1,
+              "column": 49,
+              "offset": 48
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "^wiki",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^wiki",
+              "position": {
+                "start": {
+                  "line": 1,
+                  "column": 50,
+                  "offset": 49
+                },
+                "end": {
+                  "line": 1,
+                  "column": 55,
+                  "offset": 54
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 1,
+              "column": 49,
+              "offset": 48
+            },
+            "end": {
+              "line": 1,
+              "column": 56,
+              "offset": 55
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 1,
+          "column": 1,
+          "offset": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 56,
+          "offset": 55
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "Here's the NATO phonetic alphabet",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 1,
+              "offset": 57
+            },
+            "end": {
+              "line": 3,
+              "column": 34,
+              "offset": 90
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "^wiki",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^wiki",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 35,
+                  "offset": 91
+                },
+                "end": {
+                  "line": 3,
+                  "column": 40,
+                  "offset": 96
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 34,
+              "offset": 90
+            },
+            "end": {
+              "line": 3,
+              "column": 41,
+              "offset": 97
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "^wiki2",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^wiki2",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 42,
+                  "offset": 98
+                },
+                "end": {
+                  "line": 3,
+                  "column": 48,
+                  "offset": 104
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 41,
+              "offset": 97
+            },
+            "end": {
+              "line": 3,
+              "column": 49,
+              "offset": 105
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ": Alfa, Bravo, Charlie, Delta, Echo, Foxtrot, Golf, Hotel, India, Juliet, Kilo, Lima, Mike, November, Oscar, Papa, Quebec, Romeo, Sierra, Tango, Uniform, Victor",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 49,
+              "offset": 105
+            },
+            "end": {
+              "line": 3,
+              "column": 209,
+              "offset": 265
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "^name",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^name",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 210,
+                  "offset": 266
+                },
+                "end": {
+                  "line": 3,
+                  "column": 215,
+                  "offset": 271
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 209,
+              "offset": 265
+            },
+            "end": {
+              "line": 3,
+              "column": 216,
+              "offset": 272
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "^consecutive",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^consecutive",
+              "position": {
+                "start": {
+                  "line": 3,
+                  "column": 217,
+                  "offset": 273
+                },
+                "end": {
+                  "line": 3,
+                  "column": 229,
+                  "offset": 285
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 216,
+              "offset": 272
+            },
+            "end": {
+              "line": 3,
+              "column": 230,
+              "offset": 286
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ", Whiskey, X-ray, Yankee, and Zulu.",
+          "position": {
+            "start": {
+              "line": 3,
+              "column": 230,
+              "offset": 286
+            },
+            "end": {
+              "line": 3,
+              "column": 265,
+              "offset": 321
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 3,
+          "column": 1,
+          "offset": 57
+        },
+        "end": {
+          "line": 3,
+          "column": 265,
+          "offset": 321
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "text",
+          "value": "And here's some more text.",
+          "position": {
+            "start": {
+              "line": 5,
+              "column": 1,
+              "offset": 323
+            },
+            "end": {
+              "line": 5,
+              "column": 27,
+              "offset": 349
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 5,
+          "column": 1,
+          "offset": 323
+        },
+        "end": {
+          "line": 5,
+          "column": 27,
+          "offset": 349
+        },
+        "indent": []
+      }
+    },
+    {
+      "type": "paragraph",
+      "children": [
+        {
+          "type": "linkReference",
+          "identifier": "^wiki",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^wiki",
+              "position": {
+                "start": {
+                  "line": 7,
+                  "column": 2,
+                  "offset": 352
+                },
+                "end": {
+                  "line": 7,
+                  "column": 7,
+                  "offset": 357
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 1,
+              "offset": 351
+            },
+            "end": {
+              "line": 7,
+              "column": 8,
+              "offset": 358
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ": Read more about it here.\n",
+          "position": {
+            "start": {
+              "line": 7,
+              "column": 8,
+              "offset": 358
+            },
+            "end": {
+              "line": 8,
+              "column": 1,
+              "offset": 385
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "^wiki2",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^wiki2",
+              "position": {
+                "start": {
+                  "line": 8,
+                  "column": 2,
+                  "offset": 386
+                },
+                "end": {
+                  "line": 8,
+                  "column": 8,
+                  "offset": 392
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 8,
+              "column": 1,
+              "offset": 385
+            },
+            "end": {
+              "line": 8,
+              "column": 9,
+              "offset": 393
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ": Here's another good article on the subject.\n",
+          "position": {
+            "start": {
+              "line": 8,
+              "column": 9,
+              "offset": 393
+            },
+            "end": {
+              "line": 9,
+              "column": 1,
+              "offset": 439
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "^name",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^name",
+              "position": {
+                "start": {
+                  "line": 9,
+                  "column": 2,
+                  "offset": 440
+                },
+                "end": {
+                  "line": 9,
+                  "column": 7,
+                  "offset": 445
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 1,
+              "offset": 439
+            },
+            "end": {
+              "line": 9,
+              "column": 8,
+              "offset": 446
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ": A great first name.\n",
+          "position": {
+            "start": {
+              "line": 9,
+              "column": 8,
+              "offset": 446
+            },
+            "end": {
+              "line": 10,
+              "column": 1,
+              "offset": 468
+            },
+            "indent": [
+              1
+            ]
+          }
+        },
+        {
+          "type": "linkReference",
+          "identifier": "^consecutive",
+          "referenceType": "shortcut",
+          "children": [
+            {
+              "type": "text",
+              "value": "^consecutive",
+              "position": {
+                "start": {
+                  "line": 10,
+                  "column": 2,
+                  "offset": 469
+                },
+                "end": {
+                  "line": 10,
+                  "column": 14,
+                  "offset": 481
+                },
+                "indent": []
+              }
+            }
+          ],
+          "position": {
+            "start": {
+              "line": 10,
+              "column": 1,
+              "offset": 468
+            },
+            "end": {
+              "line": 10,
+              "column": 15,
+              "offset": 482
+            },
+            "indent": []
+          }
+        },
+        {
+          "type": "text",
+          "value": ": I know.",
+          "position": {
+            "start": {
+              "line": 10,
+              "column": 15,
+              "offset": 482
+            },
+            "end": {
+              "line": 10,
+              "column": 24,
+              "offset": 491
+            },
+            "indent": []
+          }
+        }
+      ],
+      "position": {
+        "start": {
+          "line": 7,
+          "column": 1,
+          "offset": 351
+        },
+        "end": {
+          "line": 10,
+          "column": 24,
+          "offset": 491
+        },
+        "indent": [
+          1,
+          1,
+          1
+        ]
+      }
+    }
+  ],
+  "position": {
+    "start": {
+      "line": 1,
+      "column": 1,
+      "offset": 0
+    },
+    "end": {
+      "line": 11,
+      "column": 1,
+      "offset": 492
+    }
+  }
+}


### PR DESCRIPTION
Here is an attempt to solve #259 

This is preliminary work, I don't expect tests to pass. It is unclear to me how this should behave for each combination of options, I don't know much about CommonMark for instance and GFM doesn't have footnotes support anyway.

Please tell me what you think is the best way to handle this, @wooorm :)