### PR TITLE
Change require in defaults.js.

### DIFF
--- a/packages/remark-parse/lib/defaults.js
+++ b/packages/remark-parse/lib/defaults.js
@@ -16,6 +16,6 @@ module.exports = {
   commonmark: false,
   footnotes: false,
   pedantic: false,
-  blocks: require('./block-elements'),
+  blocks: require('./block-elements.json'),
   breaks: false
 };


### PR DESCRIPTION
Some setups don't work without the file extension. This will work with
all setups.