### PR TITLE
Explicitly require `block-elements.json`

### DIFF
--- a/packages/remark-parse/lib/defaults.js
+++ b/packages/remark-parse/lib/defaults.js
@@ -16,6 +16,6 @@ module.exports = {
   commonmark: false,
   footnotes: false,
   pedantic: false,
-  blocks: require('./block-elements'),
+  blocks: require('./block-elements.json'),
   breaks: false
 };


### PR DESCRIPTION
This fixes the error when Webpack3 is used and json is not part of the resolve config (see: https://github.com/grommet/grommet/issues/1018#issuecomment-256805982).

```
Module not found: Error: Can't resolve './block-elements' in '/Users/pkuczynski/Projects/shaker/node_modules/remark-parse/lib'
 @ ./node_modules/remark-parse/lib/defaults.js 19:10-37
 @ ./node_modules/remark-parse/lib/parser.js
 @ ./node_modules/remark-parse/index.js
```