### PR TITLE
Add remark-shortcodes to plugins list

### DIFF
--- a/doc/plugins.md
+++ b/doc/plugins.md
@@ -134,6 +134,8 @@ Have a good idea for a new plugin?  Let’s [chat][gitter] and make it happen!
     — [retext](https://github.com/wooorm/retext) support
 *   [`remark-rewrite-headers`](https://github.com/strugee/remark-rewrite-headers)
     — Change heading levels
+*   [`remark-shortcodes`](https://github.com/djm/remark-shortcodes)
+    — Parses custom Wordpress/Hugo-like shortcodes inside your Markdown
 *   [`remark-slug`](https://github.com/wooorm/remark-slug)
     — Add slugs to headings
 *   [`remark-strip-badges`](https://github.com/wooorm/remark-strip-badges)


### PR DESCRIPTION
Hi,

Thanks for your work on Remark!

I've created a Markdown plugin which parses Wordpress/Hugo-like block-level shortcodes. It's a simple parser and just updates the AST with the appropriate details, the idea being that other plugins can then handle the transformation to something more meaningful like a template partial.

More here: https://www.npmjs.com/package/remark-shortcodes

Cheers!
Darian 